### PR TITLE
feat: enhance admin approvals ui

### DIFF
--- a/docs/service-flow.md
+++ b/docs/service-flow.md
@@ -1,0 +1,76 @@
+# Service Flow Overview
+
+This guide introduces new contributors to the end-to-end flow of the Collection Services app and shows how the reusable service layer keeps the backend consistent.
+
+## High-level architecture
+
+```mermaid
+flowchart TD
+  subgraph Client UI
+    AuthPage[AuthForm & other pages]
+  end
+  subgraph Frontend Helpers
+    AuthSvc[src/services/authService.ts]
+  end
+  subgraph Client Storage
+    AuthStorage[(Browser localStorage)]
+  end
+  subgraph API Routes
+    BookingAPI[/api/booking]
+    DocumentAPI[/api/documents]
+    FeedbackAPI[/api/feedback]
+  end
+  subgraph Backend Services
+    BookingSvc[bookingService]
+    DocumentSvc[documentService]
+    FeedbackSvc[feedbackService]
+    Validators[utils/validators]
+    Responses[utils/responses]
+  end
+
+  AuthPage --> AuthSvc
+  AuthSvc --> AuthStorage
+
+  AuthPage --> BookingAPI
+  BookingAPI --> BookingSvc
+  BookingSvc --> Validators
+
+  AuthPage --> DocumentAPI
+  DocumentAPI --> DocumentSvc
+  DocumentSvc --> Validators
+
+  AuthPage --> FeedbackAPI
+  FeedbackAPI --> FeedbackSvc
+  FeedbackSvc --> Validators
+
+  BookingAPI --> Responses
+  DocumentAPI --> Responses
+  FeedbackAPI --> Responses
+```
+
+## How requests move through the stack
+
+### 1. Client components
+- Screens such as the login/register view render the `AuthForm` component, which maintains form state, calls the appropriate helper, and redirects or surfaces feedback after the request resolves.
+- Other feature screens (booking, documents, feedback) submit JSON payloads straight to their matching API endpoints.
+
+### 2. Frontend helpers
+- `src/services/authService.ts` now reads and writes user accounts directly from `localStorage`, guaranteeing that authentication stays entirely on the client. Shared helpers normalize usernames, detect duplicates, and ensure roles follow the "contains 'admin' => admin" rule so that the UI can remain lean.
+
+### 3. API layer
+- Each route under `src/app/api` (bookings, documents, feedback) parses the incoming JSON, delegates to the corresponding backend service, and normalizes the response via the shared helpers.
+- Authentication no longer traverses these API routes; all login and registration calls resolve entirely on the client through the local storage helpers above.
+
+### 4. Backend service helpers
+- Domain services (`bookingService.ts`, `documentService.ts`, `feedbackService.ts`) continue to act as validation/normalization layers. They rely on `utils/validators.ts` to enforce data shape before handing the record back to the API route.
+- The previous Supabase-based auth helpers are now obsolete for the current flow; they can be revisited later if server-side persistence becomes necessary again.
+### 5. Infrastructure integration
+- Supabase clients remain available for future integrations, but authentication no longer depends on them. This means the app can run without any Supabase environment variables while keeping the domain service patterns intact for other features.
+
+## Quick start for extending services
+1. **Design the payload** you expect from the client and codify it in a new service module under `src/backend/services`. Reuse the `ensure*` helpers or add new ones in `utils/validators.ts` when you find yourself validating similar patterns.
+2. **Add an API route** in `src/app/api/<feature>/route.ts` that simply parses JSON, calls your service, and returns either `createSuccessResponse` or `createErrorResponse` depending on the outcome.
+3. **Expose a frontend helper** in `src/services` when the client needs to call your endpoint from multiple places, mirroring the approach taken in the auth service.
+4. **Connect the UI** by wiring your forms or buttons to the helper, handling loading state and surfacing success/error messages just like `AuthForm` does.
+
+Following this flow keeps the codebase consistent, makes validation logic reusable, and ensures every feature plugs into the same predictable request lifecycle.

--- a/docs/setup-next-cli.md
+++ b/docs/setup-next-cli.md
@@ -1,0 +1,26 @@
+# Next CLI 安装指南
+
+为了在本地运行本项目的 `next dev`、`next build` 等命令，需要保证 `next` CLI 已经安装并且可用。以下提供两种常见方式：
+
+## 方式一：使用 `npm` 本地安装
+1. 进入项目根目录。
+2. 执行 `npm install`（或 `pnpm install`/`yarn install`），这一步会根据 `package.json` 安装 `next` 以及其它依赖。
+3. 安装完成后，可通过 `npx next --version` 检查是否安装成功。由于 `npx` 会优先使用当前项目的 `node_modules/.bin/next`，无需额外配置就能执行 `npm run dev`、`npm run build`、`npm run lint` 等脚本。
+
+> **建议**：本仓库已经包含 `package-lock.json`/`pnpm-lock.yaml`，为了确保依赖版本一致，推荐优先使用项目约定的包管理器（通常是 `npm`）。
+
+## 方式二：全局安装（可选）
+如果希望在任何目录下都能直接使用 `next` 命令，可以进行全局安装：
+
+```bash
+npm install -g next
+```
+
+安装完成后执行 `next --version` 验证即可。需要注意的是，全局安装的版本可能与项目锁定的版本不同，通常仅在需要快速运行示例项目或脚手架时使用。实际开发仍建议使用项目本地依赖。
+
+## 常见问题
+- **提示找不到 `next` 命令**：请确认已经执行依赖安装，或使用 `npx next` 运行。
+- **权限不足**：在部分系统上进行全局安装时可能需要管理员权限，可使用 `sudo npm install -g next` 或配置 `npm` 的全局目录。
+- **Node.js 版本过低**：Next.js 15 需要 Node.js 18.18 及以上版本，请先升级 Node.js。
+
+按照以上步骤操作后，即可在本地顺利运行 Next CLI，配合现有代码完成登录、注册等页面的开发和调试。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "collection_service",
-  "version": "1.1.0",
-  "author": "Yunxiang Fan",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
+  "author": "Yunxiang Fan",
   "packages": {
     "": {
       "name": "collection_service",
-      "version": "1.2.0",
+      "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.4",
         "apexcharts": "^4.5.0",
+        "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
+        "dotenv": "^17.2.2",
         "flatpickr": "^4.6.13",
         "jsvectormap": "^1.6.0",
         "next": "15.1.6",
@@ -34,6 +37,7 @@
         "prettier": "^3.4.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^3.4.16",
+        "tsx": "^4.20.5",
         "typescript": "^5"
       }
     },
@@ -81,6 +85,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -949,6 +1395,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "node_modules/@svgdotjs/svg.draggable.js": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.draggable.js/-/svg.draggable.js-3.0.6.tgz",
@@ -1056,11 +1576,16 @@
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.0.8",
@@ -1080,6 +1605,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1784,6 +2318,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1846,6 +2386,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1969,7 +2520,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2163,6 +2713,18 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2343,6 +2905,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2380,11 +2951,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2486,7 +3068,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2496,7 +3077,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2534,7 +3114,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2547,7 +3126,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2588,6 +3166,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escalade": {
@@ -3170,6 +3790,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3201,6 +3841,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3236,7 +3892,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3277,7 +3932,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3302,7 +3956,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3437,7 +4090,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3509,7 +4161,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3522,7 +4173,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3538,7 +4188,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4260,7 +4909,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4288,6 +4936,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5088,6 +5757,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6106,6 +6781,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
@@ -6144,6 +6825,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6273,7 +6974,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -6323,6 +7023,22 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6532,6 +7248,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+
+import { processBooking } from '@/backend/services/bookingService'
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from '@/backend/utils/responses'
+
+const SUCCESS_MESSAGE = 'Booking processed successfully'
+const ERROR_MESSAGE = 'Failed to process booking.'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+
+    const record = await processBooking(body)
+
+    return NextResponse.json(
+      createSuccessResponse(SUCCESS_MESSAGE, record),
+      { status: 201 },
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ERROR_MESSAGE
+
+    return NextResponse.json(createErrorResponse(message), {
+      status: 400,
+    })
+  }
+}

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+
+import { handleDocumentRequest } from '@/backend/services/documentService'
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from '@/backend/utils/responses'
+
+const SUCCESS_MESSAGE = 'Document request submitted successfully'
+const ERROR_MESSAGE = 'Failed to handle document request.'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+
+    const record = await handleDocumentRequest(body)
+
+    return NextResponse.json(
+      createSuccessResponse(SUCCESS_MESSAGE, record),
+      { status: 201 },
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ERROR_MESSAGE
+
+    return NextResponse.json(createErrorResponse(message), {
+      status: 400,
+    })
+  }
+}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+
+import { submitFeedback } from '@/backend/services/feedbackService'
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from '@/backend/utils/responses'
+
+const SUCCESS_MESSAGE = 'Feedback submitted successfully'
+const ERROR_MESSAGE = 'Failed to submit feedback.'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+
+    const record = await submitFeedback(body)
+
+    return NextResponse.json(
+      createSuccessResponse(SUCCESS_MESSAGE, record),
+      { status: 201 },
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ERROR_MESSAGE
+
+    return NextResponse.json(createErrorResponse(message), {
+      status: 400,
+    })
+  }
+}

--- a/src/app/approvals/_components/createApprovalPage.tsx
+++ b/src/app/approvals/_components/createApprovalPage.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
+import { getCurrentUser } from "@/services/authService";
+import type { CurrentUser } from "@/services/authService";
+import {
+  listSubmissions,
+  updateSubmissionStatus,
+  type SubmissionRecord,
+  type SubmissionStatus,
+  type SubmissionType,
+} from "@/services/submissionService";
+
+type DecisionStatus = Exclude<SubmissionStatus, "pending">;
+
+type ColumnConfig<T extends SubmissionType> = {
+  header: string;
+  className?: string;
+  render: (submission: SubmissionRecord<T>) => ReactNode;
+};
+
+type ApprovalPageConfig<T extends SubmissionType> = {
+  type: T;
+  title: string;
+  description: string;
+  emptyLabel: string;
+  columns: ColumnConfig<T>[];
+  renderDetails?: (submission: SubmissionRecord<T>) => ReactNode;
+};
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+export function createApprovalPage<T extends SubmissionType>({
+  type,
+  title,
+  description,
+  columns,
+  emptyLabel,
+  renderDetails,
+}: ApprovalPageConfig<T>) {
+  return function SubmissionApprovalPage() {
+    const [currentUser, setCurrentUser] = useState<CurrentUser | null>(() => getCurrentUser());
+    const [submissions, setSubmissions] = useState<SubmissionRecord<T>[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [expandedSubmissionId, setExpandedSubmissionId] = useState<string | null>(null);
+    const submissionType = useRef(type);
+
+    useEffect(() => {
+      setSubmissions(listSubmissions(submissionType.current));
+    }, []);
+
+    useEffect(() => {
+      if (!isBrowser()) {
+        return;
+      }
+
+      const handleStorage = (event: StorageEvent) => {
+        if (event.key === "collection-services.current-user") {
+          setCurrentUser(getCurrentUser());
+          return;
+        }
+
+        if (!event.key || event.key.endsWith(`${submissionType.current}-submissions`)) {
+          setSubmissions(listSubmissions(submissionType.current));
+        }
+      };
+
+      window.addEventListener("storage", handleStorage);
+
+      return () => {
+        window.removeEventListener("storage", handleStorage);
+      };
+    }, []);
+
+    const handleDecision = (submissionId: string, decision: DecisionStatus) => {
+      setError(null);
+
+      try {
+        const updatedSubmission = updateSubmissionStatus(
+          submissionType.current,
+          submissionId,
+          decision,
+          currentUser,
+        );
+        setSubmissions((prev) =>
+          prev.map((submission) =>
+            submission.id === submissionId ? updatedSubmission : submission,
+          ),
+        );
+        setExpandedSubmissionId(null);
+      } catch (decisionError) {
+        if (decisionError instanceof Error) {
+          setError(decisionError.message);
+        } else {
+          setError("Failed to update the submission status.");
+        }
+      }
+    };
+
+    const toggleDetails = (submissionId: string) => {
+      setExpandedSubmissionId((current) => (current === submissionId ? null : submissionId));
+    };
+
+    if (!currentUser || currentUser.role !== "admin") {
+      return (
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{title}</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Administrator access is required to review submissions.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-8">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{title}</h1>
+            <p className="text-sm text-gray-600 dark:text-gray-300">{description}</p>
+          </div>
+
+          {error && (
+            <p className="mt-4 rounded-md bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
+          )}
+        </div>
+
+        <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Incoming submissions</h2>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+            Review the pending requests below and record your decision.
+          </p>
+
+          <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+            <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  {columns.map((column) => (
+                    <th
+                      key={column.header}
+                      className={`px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200 ${column.className ?? ""}`.trim()}
+                    >
+                      {column.header}
+                    </th>
+                  ))}
+                  <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {submissions.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400" colSpan={columns.length + 1}>
+                      {emptyLabel}
+                    </td>
+                  </tr>
+                ) : (
+                  submissions.map((submission) => (
+                    <Fragment key={submission.id}>
+                      <tr className="bg-white dark:bg-gray-950">
+                        {columns.map((column) => (
+                          <td
+                            key={`${submission.id}-${column.header}`}
+                            className={`px-4 py-3 text-sm text-gray-900 dark:text-gray-100 ${column.className ?? ""}`.trim()}
+                          >
+                            {column.render(submission)}
+                          </td>
+                        ))}
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={() => toggleDetails(submission.id)}
+                              className="inline-flex items-center rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 shadow-sm transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800"
+                            >
+                              {expandedSubmissionId === submission.id ? "Hide details" : "View details"}
+                            </button>
+                            {submission.status === "pending" ? (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => handleDecision(submission.id, "approved")}
+                                  className="inline-flex items-center rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+                                >
+                                  Approve
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => handleDecision(submission.id, "rejected")}
+                                  className="inline-flex items-center rounded-md bg-rose-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2"
+                                >
+                                  Reject
+                                </button>
+                              </>
+                            ) : (
+                              <span className="inline-flex items-center rounded-md bg-gray-100 px-3 py-1 text-xs font-medium capitalize text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                                {submission.status}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                      {expandedSubmissionId === submission.id && (
+                        <tr>
+                          <td
+                            colSpan={columns.length + 1}
+                            className="bg-gray-50 px-4 py-5 text-sm text-gray-700 dark:bg-gray-900/60 dark:text-gray-200"
+                          >
+                            {renderDetails ? (
+                              renderDetails(submission)
+                            ) : (
+                              <pre className="whitespace-pre-wrap break-words text-xs">
+                                {JSON.stringify(submission.payload, null, 2)}
+                              </pre>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    );
+  };
+}

--- a/src/app/approvals/booking/page.tsx
+++ b/src/app/approvals/booking/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { createApprovalPage } from "../_components/createApprovalPage";
+
+const BookingApprovalPage = createApprovalPage({
+  type: "booking",
+  title: "Booking Service Approvals",
+  description:
+    "Review appointment requests from users and confirm whether the requested slot can be honored.",
+  emptyLabel: "There are no booking requests waiting for approval.",
+  columns: [
+    {
+      header: "Request",
+      render: (submission) => (
+        <div className="space-y-1">
+          <p className="font-medium text-gray-900 dark:text-gray-100">
+            {submission.payload.serviceName}
+          </p>
+          {submission.payload.notes ? (
+            <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
+              {submission.payload.notes}
+            </p>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      header: "Preferred slot",
+      className: "whitespace-nowrap",
+      render: (submission) =>
+        new Date(
+          `${submission.payload.preferredDate}T${submission.payload.preferredTime || "00:00"}`,
+        ).toLocaleString(),
+    },
+    {
+      header: "Requested by",
+      className: "whitespace-nowrap",
+      render: (submission) => submission.submittedBy,
+    },
+    {
+      header: "Status",
+      className: "whitespace-nowrap",
+      render: (submission) => (
+        <span className="capitalize text-gray-900 dark:text-gray-100">
+          {submission.status}
+        </span>
+      ),
+    },
+  ],
+  renderDetails: (submission) => (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Service</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.serviceName}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Preferred schedule</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {new Date(`${submission.payload.preferredDate}T${submission.payload.preferredTime || "00:00"}`).toLocaleString()}
+        </p>
+      </div>
+      {submission.payload.notes ? (
+        <div className="space-y-1 md:col-span-2">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Additional notes</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.notes}</p>
+        </div>
+      ) : null}
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Requested by</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{new Date(submission.createdAt).toLocaleString()}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
+        <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
+      </div>
+      {submission.decisionBy ? (
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewed by</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {submission.decisionBy}
+            {submission.decidedAt
+              ? ` · ${new Date(submission.decidedAt).toLocaleString()}`
+              : ""}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  ),
+});
+
+export default BookingApprovalPage;

--- a/src/app/approvals/documents/page.tsx
+++ b/src/app/approvals/documents/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { createApprovalPage } from "../_components/createApprovalPage";
+
+const DocumentApprovalPage = createApprovalPage({
+  type: "document",
+  title: "Document Service Approvals",
+  description:
+    "Review document requests submitted by users and confirm whether the requested materials can be issued.",
+  emptyLabel: "There are no document requests waiting for approval.",
+  columns: [
+    {
+      header: "Document",
+      render: (submission) => (
+        <div className="space-y-1">
+          <p className="font-medium text-gray-900 dark:text-gray-100">
+            {submission.payload.documentType}
+          </p>
+          <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
+            {submission.payload.justification}
+          </p>
+        </div>
+      ),
+    },
+    {
+      header: "Needed by",
+      className: "whitespace-nowrap",
+      render: (submission) =>
+        submission.payload.requiredBy
+          ? new Date(`${submission.payload.requiredBy}T00:00`).toLocaleDateString()
+          : "Not specified",
+    },
+    {
+      header: "Requested by",
+      className: "whitespace-nowrap",
+      render: (submission) => submission.submittedBy,
+    },
+    {
+      header: "Status",
+      className: "whitespace-nowrap",
+      render: (submission) => (
+        <span className="capitalize text-gray-900 dark:text-gray-100">
+          {submission.status}
+        </span>
+      ),
+    },
+  ],
+  renderDetails: (submission) => (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Document</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.documentType}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Needed by</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {submission.payload.requiredBy
+            ? new Date(`${submission.payload.requiredBy}T00:00`).toLocaleDateString()
+            : "Not specified"}
+        </p>
+      </div>
+      <div className="space-y-1 md:col-span-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Justification</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.justification}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Requested by</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{new Date(submission.createdAt).toLocaleString()}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
+        <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
+      </div>
+      {submission.decisionBy ? (
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewed by</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {submission.decisionBy}
+            {submission.decidedAt
+              ? ` · ${new Date(submission.decidedAt).toLocaleString()}`
+              : ""}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  ),
+});
+
+export default DocumentApprovalPage;

--- a/src/app/approvals/feedback/page.tsx
+++ b/src/app/approvals/feedback/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { createApprovalPage } from "../_components/createApprovalPage";
+
+const FeedbackApprovalPage = createApprovalPage({
+  type: "feedback",
+  title: "Feedback Service Approvals",
+  description:
+    "Review feedback submissions from end users and approve them once they have been addressed.",
+  emptyLabel: "There are no feedback submissions waiting for review.",
+  columns: [
+    {
+      header: "Feedback",
+      render: (submission) => (
+        <div className="space-y-1">
+          <p className="font-medium text-gray-900 dark:text-gray-100">
+            {submission.payload.subject}
+          </p>
+          <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
+            {submission.payload.details}
+          </p>
+        </div>
+      ),
+    },
+    {
+      header: "Submitted by",
+      className: "whitespace-nowrap",
+      render: (submission) => submission.submittedBy,
+    },
+    {
+      header: "Submitted",
+      className: "whitespace-nowrap",
+      render: (submission) => new Date(submission.createdAt).toLocaleString(),
+    },
+    {
+      header: "Status",
+      className: "whitespace-nowrap",
+      render: (submission) => (
+        <span className="capitalize text-gray-900 dark:text-gray-100">
+          {submission.status}
+        </span>
+      ),
+    },
+  ],
+  renderDetails: (submission) => (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Feedback details</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.details}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Subject</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.subject}</p>
+      </div>
+      {submission.payload.contactMethod ? (
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Preferred contact</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.contactMethod}</p>
+        </div>
+      ) : null}
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {new Date(submission.createdAt).toLocaleString()}
+        </p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
+        <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
+      </div>
+      {submission.decisionBy ? (
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewed by</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {submission.decisionBy}
+            {submission.decidedAt
+              ? ` · ${new Date(submission.decidedAt).toLocaleString()}`
+              : ""}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  ),
+});
+
+export default FeedbackApprovalPage;

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,70 +1,10 @@
-import Signin from "@/components/Auth/Signin";
-import Breadcrumb from "@/components/Breadcrumbs/Breadcrumb";
 import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
-  title: "Sign in",
+  title: "Sign In",
 };
 
 export default function SignIn() {
-  return (
-    <>
-      <Breadcrumb pageName="Sign In" />
-
-      <div className="rounded-[10px] bg-white shadow-1 dark:bg-gray-dark dark:shadow-card">
-        <div className="flex flex-wrap items-center">
-          <div className="w-full xl:w-1/2">
-            <div className="w-full p-4 sm:p-12.5 xl:p-15">
-              <Signin />
-            </div>
-          </div>
-
-          <div className="hidden w-full p-7.5 xl:block xl:w-1/2">
-            <div className="custom-gradient-1 overflow-hidden rounded-2xl px-12.5 pt-12.5 dark:!bg-dark-2 dark:bg-none">
-              <Link className="mb-10 inline-block" href="/">
-                <Image
-                  className="hidden dark:block"
-                  src={"/images/logo/logo.svg"}
-                  alt="Logo"
-                  width={176}
-                  height={32}
-                />
-                <Image
-                  className="dark:hidden"
-                  src={"/images/logo/logo-dark.svg"}
-                  alt="Logo"
-                  width={176}
-                  height={32}
-                />
-              </Link>
-              <p className="mb-3 text-xl font-medium text-dark dark:text-white">
-                Sign in to your account
-              </p>
-
-              <h1 className="mb-4 text-2xl font-bold text-dark dark:text-white sm:text-heading-3">
-                Welcome Back!
-              </h1>
-
-              <p className="w-full max-w-[375px] font-medium text-dark-4 dark:text-dark-6">
-                Please sign in to your account by completing the necessary
-                fields below
-              </p>
-
-              <div className="mt-31">
-                <Image
-                  src={"/images/grids/grid-02.svg"}
-                  alt="Logo"
-                  width={405}
-                  height={325}
-                  className="mx-auto dark:opacity-30"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </>
-  );
+  redirect("/login");
 }

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import type { CurrentUser } from "@/services/authService";
+import { getCurrentUser } from "@/services/authService";
+import {
+  createSubmission,
+  listSubmissionsForUser,
+  type BookingPayload,
+  type SubmissionRecord,
+} from "@/services/submissionService";
+
+export default function BookingPage() {
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(() => getCurrentUser());
+  const [serviceName, setServiceName] = useState("");
+  const [preferredDate, setPreferredDate] = useState("");
+  const [preferredTime, setPreferredTime] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submissions, setSubmissions] = useState<SubmissionRecord<"booking">[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const username = useMemo(() => currentUser?.username ?? "", [currentUser]);
+
+  useEffect(() => {
+    if (!username) {
+      setSubmissions([]);
+      return;
+    }
+
+    setSubmissions(listSubmissionsForUser("booking", username));
+  }, [username]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === "collection-services.current-user") {
+        setCurrentUser(getCurrentUser());
+      }
+
+      if (!event.key || event.key === "collection-services.booking-submissions") {
+        if (username) {
+          setSubmissions(listSubmissionsForUser("booking", username));
+        }
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, [username]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage(null);
+    setError(null);
+
+    try {
+      const payload: BookingPayload = {
+        serviceName: serviceName.trim(),
+        preferredDate,
+        preferredTime,
+        notes: notes.trim() || undefined,
+      };
+
+      if (!payload.serviceName) {
+        throw new Error("Service name is required.");
+      }
+
+      if (!payload.preferredDate) {
+        throw new Error("Preferred date is required.");
+      }
+
+      if (!payload.preferredTime) {
+        throw new Error("Preferred time is required.");
+      }
+
+      const newSubmission = createSubmission("booking", payload, currentUser);
+      setSubmissions((prev) => [...prev, newSubmission]);
+
+      setServiceName("");
+      setPreferredDate("");
+      setPreferredTime("");
+      setNotes("");
+      setMessage("Booking request submitted successfully.");
+    } catch (submissionError) {
+      if (submissionError instanceof Error) {
+        setError(submissionError.message);
+      } else {
+        setError("An unexpected error occurred while creating the booking request.");
+      }
+    }
+  };
+
+  if (!currentUser) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Booking Service</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          You need to sign in before scheduling a booking.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-6 space-y-1">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Booking Service</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Request an appointment with our team. We will confirm once it is reviewed.
+          </p>
+        </div>
+
+        {message && (
+          <p className="mb-4 rounded-md bg-green-50 px-4 py-2 text-sm text-green-700">
+            {message}
+          </p>
+        )}
+
+        {error && (
+          <p className="mb-4 rounded-md bg-red-50 px-4 py-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="serviceName">
+              Service name
+            </label>
+            <input
+              id="serviceName"
+              name="serviceName"
+              value={serviceName}
+              onChange={(event) => setServiceName(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Consultation, onboarding, etc."
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="preferredDate">
+                Preferred date
+              </label>
+              <input
+                type="date"
+                id="preferredDate"
+                name="preferredDate"
+                value={preferredDate}
+                onChange={(event) => setPreferredDate(event.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="preferredTime">
+                Preferred time
+              </label>
+              <input
+                type="time"
+                id="preferredTime"
+                name="preferredTime"
+                value={preferredTime}
+                onChange={(event) => setPreferredTime(event.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="notes">
+              Additional notes (optional)
+            </label>
+            <textarea
+              id="notes"
+              name="notes"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              className="h-24 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Share any important context for the appointment"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Submit booking request
+          </button>
+        </form>
+      </div>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Submission history</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Track the status of your booking requests.
+        </p>
+
+        <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Service</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Preferred slot</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              {submissions.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400" colSpan={3}>
+                    You have not created any booking requests yet.
+                  </td>
+                </tr>
+              ) : (
+                submissions.map((submission) => (
+                  <tr key={submission.id} className="bg-white dark:bg-gray-950">
+                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                      {submission.payload.serviceName}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                      {new Date(`${submission.payload.preferredDate}T${submission.payload.preferredTime || "00:00"}`).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                      {submission.status}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { getCurrentUser } from "@/services/authService";
+import type { CurrentUser } from "@/services/authService";
+import {
+  createSubmission,
+  listSubmissionsForUser,
+  type DocumentPayload,
+  type SubmissionRecord,
+} from "@/services/submissionService";
+
+export default function DocumentRequestPage() {
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(() => getCurrentUser());
+  const [documentType, setDocumentType] = useState("");
+  const [justification, setJustification] = useState("");
+  const [requiredBy, setRequiredBy] = useState("");
+  const [submissions, setSubmissions] = useState<SubmissionRecord<"document">[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const username = useMemo(() => currentUser?.username ?? "", [currentUser]);
+
+  useEffect(() => {
+    if (!username) {
+      setSubmissions([]);
+      return;
+    }
+
+    setSubmissions(listSubmissionsForUser("document", username));
+  }, [username]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === "collection-services.current-user") {
+        setCurrentUser(getCurrentUser());
+      }
+
+      if (!event.key || event.key === "collection-services.document-submissions") {
+        if (username) {
+          setSubmissions(listSubmissionsForUser("document", username));
+        }
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, [username]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage(null);
+    setError(null);
+
+    try {
+      const payload: DocumentPayload = {
+        documentType: documentType.trim(),
+        justification: justification.trim(),
+        requiredBy: requiredBy || undefined,
+      };
+
+      if (!payload.documentType) {
+        throw new Error("Document type is required.");
+      }
+
+      if (!payload.justification) {
+        throw new Error("Justification is required.");
+      }
+
+      const newSubmission = createSubmission("document", payload, currentUser);
+      setSubmissions((prev) => [...prev, newSubmission]);
+
+      setDocumentType("");
+      setJustification("");
+      setRequiredBy("");
+      setMessage("Document request submitted successfully.");
+    } catch (submissionError) {
+      if (submissionError instanceof Error) {
+        setError(submissionError.message);
+      } else {
+        setError("An unexpected error occurred while submitting the document request.");
+      }
+    }
+  };
+
+  if (!currentUser) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Document Request Service</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          You need to sign in before requesting documents.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-6 space-y-1">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Document Request Service</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Request certificates, letters, or other documents from our team.
+          </p>
+        </div>
+
+        {message && (
+          <p className="mb-4 rounded-md bg-green-50 px-4 py-2 text-sm text-green-700">
+            {message}
+          </p>
+        )}
+
+        {error && (
+          <p className="mb-4 rounded-md bg-red-50 px-4 py-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="documentType">
+              Document type
+            </label>
+            <input
+              id="documentType"
+              name="documentType"
+              value={documentType}
+              onChange={(event) => setDocumentType(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Enrollment letter, transcript, etc."
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="justification">
+              Justification
+            </label>
+            <textarea
+              id="justification"
+              name="justification"
+              value={justification}
+              onChange={(event) => setJustification(event.target.value)}
+              className="h-28 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Explain why you need this document"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="requiredBy">
+              Required by (optional)
+            </label>
+            <input
+              type="date"
+              id="requiredBy"
+              name="requiredBy"
+              value={requiredBy}
+              onChange={(event) => setRequiredBy(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Submit document request
+          </button>
+        </form>
+      </div>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Submission history</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Track the status of your document requests.
+        </p>
+
+        <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Document</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Requested</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              {submissions.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400" colSpan={3}>
+                    You have not submitted any document requests yet.
+                  </td>
+                </tr>
+              ) : (
+                submissions.map((submission) => (
+                  <tr key={submission.id} className="bg-white dark:bg-gray-950">
+                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                      {submission.payload.documentType}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                      {new Date(submission.createdAt).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                      {submission.status}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { getCurrentUser } from "@/services/authService";
+import type { CurrentUser } from "@/services/authService";
+import {
+  createSubmission,
+  listSubmissionsForUser,
+  type FeedbackPayload,
+  type SubmissionRecord,
+} from "@/services/submissionService";
+
+export default function FeedbackPage() {
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(() => getCurrentUser());
+  const [subject, setSubject] = useState("");
+  const [details, setDetails] = useState("");
+  const [contactMethod, setContactMethod] = useState("");
+  const [submissions, setSubmissions] = useState<SubmissionRecord<"feedback">[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const username = useMemo(() => currentUser?.username ?? "", [currentUser]);
+
+  useEffect(() => {
+    if (!username) {
+      setSubmissions([]);
+      return;
+    }
+
+    setSubmissions(listSubmissionsForUser("feedback", username));
+  }, [username]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === "collection-services.current-user") {
+        setCurrentUser(getCurrentUser());
+      }
+
+      if (
+        !event.key ||
+        event.key === "collection-services.feedback-submissions"
+      ) {
+        if (username) {
+          setSubmissions(listSubmissionsForUser("feedback", username));
+        }
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, [username]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage(null);
+    setError(null);
+
+    try {
+      const payload: FeedbackPayload = {
+        subject: subject.trim(),
+        details: details.trim(),
+        contactMethod: contactMethod.trim() || undefined,
+      };
+
+      if (!payload.subject) {
+        throw new Error("Subject is required.");
+      }
+
+      if (!payload.details) {
+        throw new Error("Details are required.");
+      }
+
+      const newSubmission = createSubmission("feedback", payload, currentUser);
+      setSubmissions((prev) => [...prev, newSubmission]);
+
+      setSubject("");
+      setDetails("");
+      setContactMethod("");
+      setMessage("Feedback submitted successfully.");
+    } catch (submissionError) {
+      if (submissionError instanceof Error) {
+        setError(submissionError.message);
+      } else {
+        setError("An unexpected error occurred while submitting feedback.");
+      }
+    }
+  };
+
+  if (!currentUser) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Feedback Service</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          You need to sign in before submitting feedback.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-6 space-y-1">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Feedback Service</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Share your thoughts or report an issue. We review every submission carefully.
+          </p>
+        </div>
+
+        {message && (
+          <p className="mb-4 rounded-md bg-green-50 px-4 py-2 text-sm text-green-700">
+            {message}
+          </p>
+        )}
+
+        {error && (
+          <p className="mb-4 rounded-md bg-red-50 px-4 py-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="subject">
+              Subject
+            </label>
+            <input
+              id="subject"
+              name="subject"
+              value={subject}
+              onChange={(event) => setSubject(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Let us know how we can help"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="details">
+              Details
+            </label>
+            <textarea
+              id="details"
+              name="details"
+              value={details}
+              onChange={(event) => setDetails(event.target.value)}
+              className="h-32 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Please provide as much detail as possible"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="contactMethod">
+              Preferred contact method (optional)
+            </label>
+            <input
+              id="contactMethod"
+              name="contactMethod"
+              value={contactMethod}
+              onChange={(event) => setContactMethod(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Email, phone number, or other"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Submit feedback
+          </button>
+        </form>
+      </div>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Submission history</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Track the status of your previous feedback submissions.
+        </p>
+
+        <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Subject</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted at</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              {submissions.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400" colSpan={3}>
+                    You have not submitted any feedback yet.
+                  </td>
+                </tr>
+              ) : (
+                submissions.map((submission) => (
+                  <tr key={submission.id} className="bg-white dark:bg-gray-950">
+                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                      {submission.payload.subject}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                      {new Date(submission.createdAt).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                      {submission.status}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,10 @@
 import "@/css/satoshi.css";
 import "@/css/style.css";
 
-import { Sidebar } from "@/components/Layouts/sidebar";
-
 import "flatpickr/dist/flatpickr.min.css";
 import "jsvectormap/dist/jsvectormap.css";
 
-import { Header } from "@/components/Layouts/header";
+import { AppShell } from "@/components/Layouts/AppShell";
 import type { Metadata } from "next";
 import NextTopLoader from "nextjs-toploader";
 import type { PropsWithChildren } from "react";
@@ -14,8 +12,8 @@ import { Providers } from "./providers";
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | NextAdmin - Next.js Dashboard Kit",
-    default: "NextAdmin - Next.js Dashboard Kit",
+    template: "%s | collection-services - Next.js Dashboard Kit",
+    default: "collection-services - Next.js Dashboard Kit",
   },
   description:
     "Next.js admin dashboard toolkit with 200+ templates, UI components, and integrations for fast dashboard development.",
@@ -27,18 +25,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       <body>
         <Providers>
           <NextTopLoader color="#5750F1" showSpinner={false} />
-
-          <div className="flex min-h-screen">
-            <Sidebar />
-
-            <div className="w-full bg-gray-2 dark:bg-[#020d1a]">
-              <Header />
-
-              <main className="isolate mx-auto w-full max-w-screen-2xl overflow-hidden p-4 md:p-6 2xl:p-10">
-                {children}
-              </main>
-            </div>
-          </div>
+          <AppShell>{children}</AppShell>
         </Providers>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,44 @@
+import Signin from "@/components/Auth/Signin";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Login",
+};
+
+export default function LoginPage() {
+  return (
+    <div className="relative flex min-h-screen bg-gray-2 dark:bg-[#020d1a]">
+      <div className="relative hidden flex-1 items-center justify-center overflow-hidden bg-primary/10 p-12 text-white dark:bg-primary/20 lg:flex">
+        <div className="max-w-xl text-left">
+          <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-white/70">
+            Collection Services
+          </p>
+          <h1 className="mb-6 text-4xl font-bold leading-tight">
+            Your data operations dashboard
+          </h1>
+          <p className="text-base text-white/80">
+            Sign in to continue where you left off or create a new account to
+            unlock analytics, automation, and more.
+          </p>
+        </div>
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(87,80,241,0.3),transparent_60%)]" />
+      </div>
+
+      <div className="flex w-full flex-col justify-center px-6 py-16 sm:px-12 lg:w-[480px] lg:px-16 xl:w-[520px]">
+        <div className="mx-auto w-full max-w-md space-y-8">
+          <div className="space-y-3 text-left">
+            <h2 className="text-3xl font-semibold text-dark dark:text-white">
+              Welcome back
+            </h2>
+            <p className="text-base text-dark-4 dark:text-dark-6">
+              Sign in to access your workspace or create a new account in a few
+              steps.
+            </p>
+          </div>
+
+          <Signin />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/backend/lib/supabaseClient.ts
+++ b/src/backend/lib/supabaseClient.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js'
+import * as dotenv from 'dotenv'
+
+// Ensure environment variables from .env.local are available when running locally
+if (!process.env.SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_URL) {
+  dotenv.config({ path: '.env.local' })
+}
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl) {
+  throw new Error('Supabase URL is not configured. Set SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL.')
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Supabase anon key is not configured. Set NEXT_PUBLIC_SUPABASE_ANON_KEY.')
+}
+
+if (!supabaseServiceRoleKey) {
+  throw new Error('Supabase service role key is not configured. Set SUPABASE_SERVICE_ROLE_KEY.')
+}
+
+export const supabaseServerClient = createClient(supabaseUrl, supabaseAnonKey)
+export const supabaseAdminClient = createClient(supabaseUrl, supabaseServiceRoleKey)
+
+export const DEFAULT_EMAIL_DOMAIN = process.env.DEFAULT_EMAIL_DOMAIN || 'example.com'

--- a/src/backend/services/bookingService.ts
+++ b/src/backend/services/bookingService.ts
@@ -1,0 +1,86 @@
+import {
+  ensureArrayField,
+  ensureEnumField,
+  ensureIsoDateField,
+  ensureOptionalStringField,
+  ensureStringField,
+} from '@/backend/utils/validators'
+
+export const BOOKING_STATUS = ['pending', 'confirmed', 'cancelled'] as const
+
+export type BookingStatus = (typeof BOOKING_STATUS)[number]
+
+export interface BookingItemPayload {
+  name: unknown
+  description: unknown
+  status: unknown
+}
+
+export interface BookingPayload {
+  id: unknown
+  service: unknown
+  date: unknown
+  status: unknown
+  notes?: unknown
+  items: unknown
+}
+
+export interface BookingItemRecord {
+  name: string
+  description: string
+  status: string
+}
+
+export interface BookingRecord {
+  id: string
+  service: string
+  date: string
+  status: BookingStatus
+  notes?: string
+  items: BookingItemRecord[]
+}
+
+function normalizeBookingItems(items: unknown): BookingItemRecord[] {
+  const rawItems = ensureArrayField(items, 'items')
+
+  if (rawItems.length === 0) {
+    throw new Error('items must contain at least one entry.')
+  }
+
+  return rawItems.map((item, index) => {
+    if (typeof item !== 'object' || item === null) {
+      throw new Error(`items[${index}] must be an object.`)
+    }
+
+    const payload = item as BookingItemPayload
+
+    return {
+      name: ensureStringField(payload.name, `items[${index}].name`),
+      description: ensureStringField(
+        payload.description,
+        `items[${index}].description`,
+      ),
+      status: ensureStringField(payload.status, `items[${index}].status`),
+    }
+  })
+}
+
+export async function processBooking(
+  payload: BookingPayload,
+): Promise<BookingRecord> {
+  const id = ensureStringField(payload.id, 'id')
+  const service = ensureStringField(payload.service, 'service')
+  const date = ensureIsoDateField(payload.date, 'date')
+  const status = ensureEnumField(payload.status, 'status', BOOKING_STATUS)
+  const notes = ensureOptionalStringField(payload.notes, 'notes')
+  const items = normalizeBookingItems(payload.items)
+
+  return {
+    id,
+    service,
+    date,
+    status,
+    notes,
+    items,
+  }
+}

--- a/src/backend/services/documentService.ts
+++ b/src/backend/services/documentService.ts
@@ -1,0 +1,45 @@
+import {
+  ensureEnumField,
+  ensureIsoDateField,
+  ensureStringField,
+} from '@/backend/utils/validators'
+
+export const DOCUMENT_STATUS = ['pending', 'approved', 'rejected'] as const
+
+export type DocumentStatus = (typeof DOCUMENT_STATUS)[number]
+
+export interface DocumentRequestPayload {
+  id: unknown
+  type: unknown
+  status: unknown
+  requested_at: unknown
+  processed_at?: unknown
+}
+
+export interface DocumentRequestRecord {
+  id: string
+  type: string
+  status: DocumentStatus
+  requested_at: string
+  processed_at?: string
+}
+
+export async function handleDocumentRequest(
+  payload: DocumentRequestPayload,
+): Promise<DocumentRequestRecord> {
+  const id = ensureStringField(payload.id, 'id')
+  const type = ensureStringField(payload.type, 'type')
+  const status = ensureEnumField(payload.status, 'status', DOCUMENT_STATUS)
+  const requestedAt = ensureIsoDateField(payload.requested_at, 'requested_at')
+  const processedAt = ensureIsoDateField(payload.processed_at, 'processed_at', {
+    optional: true,
+  })
+
+  return {
+    id,
+    type,
+    status,
+    requested_at: requestedAt,
+    processed_at: processedAt,
+  }
+}

--- a/src/backend/services/feedbackService.ts
+++ b/src/backend/services/feedbackService.ts
@@ -1,0 +1,43 @@
+import {
+  ensureEnumField,
+  ensureIsoDateField,
+  ensureStringField,
+} from '@/backend/utils/validators'
+
+export const FEEDBACK_STATUS = ['pending', 'in_progress', 'resolved'] as const
+
+export type FeedbackStatus = (typeof FEEDBACK_STATUS)[number]
+
+export interface FeedbackPayload {
+  id: unknown
+  title: unknown
+  description: unknown
+  status: unknown
+  created_at: unknown
+}
+
+export interface FeedbackRecord {
+  id: string
+  title: string
+  description: string
+  status: FeedbackStatus
+  created_at: string
+}
+
+export async function submitFeedback(
+  payload: FeedbackPayload,
+): Promise<FeedbackRecord> {
+  const id = ensureStringField(payload.id, 'id')
+  const title = ensureStringField(payload.title, 'title')
+  const description = ensureStringField(payload.description, 'description')
+  const status = ensureEnumField(payload.status, 'status', FEEDBACK_STATUS)
+  const createdAt = ensureIsoDateField(payload.created_at, 'created_at')
+
+  return {
+    id,
+    title,
+    description,
+    status,
+    created_at: createdAt,
+  }
+}

--- a/src/backend/services/userService.ts
+++ b/src/backend/services/userService.ts
@@ -1,32 +1,63 @@
-// backend/services/authService.ts
-import { createClient } from '@supabase/supabase-js'
-import * as dotenv from 'dotenv'
+import { AuthError, AuthResponse } from '@supabase/supabase-js'
 
-// 加载 .env.local
-dotenv.config({ path: '.env.local' })
+import {
+  DEFAULT_EMAIL_DOMAIN,
+  supabaseAdminClient,
+  supabaseServerClient,
+} from '@/backend/lib/supabaseClient'
 
-// 用 service role key 初始化 admin client
-const supabaseUrl = process.env.SUPABASE_URL || 'https://eujwvgungxolozkfbxst.supabase.co'
-console.log('Supabase URL:', supabaseUrl)
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 
-'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV1and2Z3VuZ3hvbG96a2ZieHN0Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1ODI2NzUxMywiZXhwIjoyMDczODQzNTEzfQ.dcoK-DY5aPeZz2KTBeNsUROw2M6VlHFPfiVRgoxHEqQ'
-// process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-const supabaseAdmin = createClient(supabaseUrl, supabaseKey)
+export interface RegisterPayload {
+  username: string
+  password: string
+  role?: string
+  email?: string
+}
 
-/**
- * 创建 auth 用户
- * @param username 你的用户名，会拼成 email
- * @param password 明文密码，Supabase自动哈希
- * @param role 用户角色
- */
-export async function createAuthUser(username: string, password: string, role: string = 'user') {
-  // 拼一个假邮箱（必须要有 email 字段）
-  const email = `${username}@example.com`
+export interface LoginPayload {
+  password: string
+  username?: string
+  email?: string
+}
 
-  const { data, error } = await supabaseAdmin.auth.admin.createUser({
-    email,
+export interface RegisterResult {
+  id: string
+  email: string
+  role?: string
+  username?: string
+}
+
+export interface LoginResult {
+  user: AuthResponse['data']['user']
+  session: AuthResponse['data']['session']
+}
+
+const normalizeEmail = (usernameOrEmail: string) => {
+  if (usernameOrEmail.includes('@')) {
+    return usernameOrEmail
+  }
+  return `${usernameOrEmail}@${DEFAULT_EMAIL_DOMAIN}`
+}
+
+export async function registerUser({
+  username,
+  password,
+  role = 'user',
+  email,
+}: RegisterPayload): Promise<RegisterResult> {
+  if (!username) {
+    throw new Error('Username is required.')
+  }
+
+  if (!password) {
+    throw new Error('Password is required.')
+  }
+
+  const normalizedEmail = normalizeEmail(email ?? username)
+
+  const { data, error } = await supabaseAdminClient.auth.admin.createUser({
+    email: normalizedEmail,
     password,
-    email_confirm: true, // 跳过确认
+    email_confirm: true,
     user_metadata: {
       username,
       role,
@@ -34,9 +65,52 @@ export async function createAuthUser(username: string, password: string, role: s
   })
 
   if (error) {
-    console.error('创建失败:', error.message)
-    return null
+    throw new Error(error.message)
   }
-  console.log('创建成功，用户ID:', data.user?.id)
-  return data.user
+
+  if (!data.user) {
+    throw new Error('Failed to create user.')
+  }
+
+  return {
+    id: data.user.id,
+    email: data.user.email ?? normalizedEmail,
+    role: (data.user.user_metadata as { role?: string } | null)?.role ?? role,
+    username: (data.user.user_metadata as { username?: string } | null)?.username ?? username,
+  }
+}
+
+export async function loginUser({
+  username,
+  email,
+  password,
+}: LoginPayload): Promise<LoginResult> {
+  if (!password) {
+    throw new Error('Password is required.')
+  }
+
+  const identifier = username ?? email
+
+  if (!identifier) {
+    throw new Error('Please provide a username or email address.')
+  }
+
+  const normalizedEmail = normalizeEmail(identifier)
+
+  const { data, error } = await supabaseServerClient.auth.signInWithPassword({
+    email: normalizedEmail,
+    password,
+  })
+
+  if (error) {
+    if (error instanceof AuthError) {
+      throw new Error(error.message)
+    }
+    throw new Error('Login failed.')
+  }
+
+  return {
+    user: data.user,
+    session: data.session,
+  }
 }

--- a/src/backend/utils/responses.ts
+++ b/src/backend/utils/responses.ts
@@ -1,0 +1,33 @@
+export interface ApiSuccessResponse<T> {
+  success: true
+  message: string
+  data: T
+}
+
+export interface ApiErrorResponse {
+  success: false
+  message: string
+  errors?: string[]
+}
+
+export function createSuccessResponse<T>(
+  message: string,
+  data: T,
+): ApiSuccessResponse<T> {
+  return {
+    success: true,
+    message,
+    data,
+  }
+}
+
+export function createErrorResponse(
+  message: string,
+  errors?: string[],
+): ApiErrorResponse {
+  return {
+    success: false,
+    message,
+    errors,
+  }
+}

--- a/src/backend/utils/validators.ts
+++ b/src/backend/utils/validators.ts
@@ -1,0 +1,112 @@
+export function ensureStringField(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string.`)
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    throw new Error(`${fieldName} is required.`)
+  }
+
+  return trimmed
+}
+
+export function ensureOptionalStringField(
+  value: unknown,
+  fieldName: string,
+): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string.`)
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return undefined
+  }
+
+  return trimmed
+}
+
+export function ensureEnumField<const T extends readonly string[]>(
+  value: unknown,
+  fieldName: string,
+  allowedValues: T,
+): T[number] {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `${fieldName} must be one of: ${allowedValues.join(', ')}.`,
+    )
+  }
+
+  const normalized = value.trim()
+
+  if (!allowedValues.includes(normalized as T[number])) {
+    throw new Error(
+      `${fieldName} must be one of: ${allowedValues.join(', ')}.`,
+    )
+  }
+
+  return normalized as T[number]
+}
+
+export function ensureIsoDateField(
+  value: unknown,
+  fieldName: string,
+): string
+export function ensureIsoDateField(
+  value: unknown,
+  fieldName: string,
+  options: { optional: true },
+): string | undefined
+export function ensureIsoDateField(
+  value: unknown,
+  fieldName: string,
+  { optional = false }: { optional?: boolean } = {},
+): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    if (optional) {
+      return undefined
+    }
+
+    throw new Error(`${fieldName} is required.`)
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string in ISO format.`)
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    if (optional) {
+      return undefined
+    }
+
+    throw new Error(`${fieldName} is required.`)
+  }
+
+  const parsed = Date.parse(trimmed)
+
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${fieldName} must be a valid ISO date string.`)
+  }
+
+  return new Date(parsed).toISOString()
+}
+
+export function ensureArrayField(
+  value: unknown,
+  fieldName: string,
+): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldName} must be an array.`)
+  }
+
+  return value
+}

--- a/src/components/Auth/AuthForm.tsx
+++ b/src/components/Auth/AuthForm.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { PasswordIcon, UserIcon } from "@/assets/icons";
+import InputGroup from "@/components/FormElements/InputGroup";
+import { Alert } from "@/components/ui-elements/alert";
+import { Checkbox } from "@/components/FormElements/checkbox";
+import { cn } from "@/lib/utils";
+import { login, register } from "@/services/authService";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type AuthFormMode = "login" | "register";
+
+type LoginState = {
+  username: string;
+  password: string;
+  remember: boolean;
+};
+
+type RegisterState = {
+  username: string;
+  password: string;
+  confirmPassword: string;
+};
+
+type Feedback = {
+  variant: "success" | "error";
+  message: string;
+};
+
+const LOGIN_INITIAL_STATE: LoginState = {
+  username: "",
+  password: "",
+  remember: false,
+};
+
+const REGISTER_INITIAL_STATE: RegisterState = {
+  username: "",
+  password: "",
+  confirmPassword: "",
+};
+
+interface AuthFormProps {
+  mode: AuthFormMode;
+}
+
+export default function AuthForm({ mode }: AuthFormProps) {
+  const [loginState, setLoginState] = useState<LoginState>(LOGIN_INITIAL_STATE);
+  const [registerState, setRegisterState] = useState<RegisterState>(
+    REGISTER_INITIAL_STATE,
+  );
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    setFeedback(null);
+
+    if (mode === "login") {
+      setLoginState(LOGIN_INITIAL_STATE);
+      return;
+    }
+
+    setRegisterState(REGISTER_INITIAL_STATE);
+  }, [mode]);
+
+  const currentState = useMemo(
+    () => (mode === "login" ? loginState : registerState),
+    [mode, loginState, registerState],
+  );
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = event.target;
+
+    if (mode === "login") {
+      setLoginState((previous) => ({ ...previous, [name]: value }));
+      return;
+    }
+
+    setRegisterState((previous) => ({ ...previous, [name]: value }));
+  };
+
+  const handleCheckboxChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    if (mode !== "login") return;
+
+    const { checked } = event.target;
+    setLoginState((previous) => ({ ...previous, remember: checked }));
+  };
+
+  const handleSubmit = async (
+    event: React.FormEvent<HTMLFormElement>,
+  ): Promise<void> => {
+    event.preventDefault();
+    setFeedback(null);
+
+    try {
+      if (mode === "login") {
+        if (!loginState.username.trim()) {
+          throw new Error("Please enter your username.");
+        }
+
+        if (!loginState.password) {
+          throw new Error("Please enter your password.");
+        }
+
+        setLoading(true);
+
+        const response = await login({
+          username: loginState.username.trim(),
+          password: loginState.password,
+          remember: loginState.remember,
+        });
+
+        setFeedback({
+          variant: "success",
+          message: response.message || "Signed in successfully.",
+        });
+
+        setLoginState(LOGIN_INITIAL_STATE);
+        router.replace("/");
+        return;
+      }
+
+      if (!registerState.username.trim()) {
+        throw new Error("Please enter a username.");
+      }
+
+      if (!registerState.password) {
+        throw new Error("Please enter your password.");
+      }
+
+      if (registerState.password !== registerState.confirmPassword) {
+        throw new Error("Passwords do not match.");
+      }
+
+      setLoading(true);
+
+      const response = await register({
+        username: registerState.username.trim(),
+        password: registerState.password,
+      });
+
+      setFeedback({
+        variant: "success",
+        message: response.message || "Account created successfully.",
+      });
+
+      setRegisterState(REGISTER_INITIAL_STATE);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Submission failed.";
+      setFeedback({ variant: "error", message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {feedback && (
+        <Alert
+          variant={feedback.variant}
+          title={feedback.variant === "success" ? "Success" : "Error"}
+          description={feedback.message}
+        />
+      )}
+
+      {mode === "register" && (
+        <InputGroup
+          type="text"
+          label="Username"
+          placeholder="Enter your username"
+          name="username"
+          handleChange={handleChange}
+          value={(currentState as RegisterState).username}
+          iconPosition="left"
+          icon={<UserIcon className="text-dark-4" />}
+          required
+        />
+      )}
+
+      {mode === "login" && (
+        <InputGroup
+          type="text"
+          label="Username"
+          placeholder="Enter your username"
+          name="username"
+          handleChange={handleChange}
+          value={(currentState as LoginState).username}
+          iconPosition="left"
+          icon={<UserIcon className="text-dark-4" />}
+          required
+        />
+      )}
+
+      <InputGroup
+        type="password"
+        label="Password"
+        placeholder={
+          mode === "login" ? "Enter your password" : "Create a password"
+        }
+        name="password"
+        handleChange={handleChange}
+        value={currentState.password}
+        iconPosition="left"
+        icon={<PasswordIcon className="text-dark-4" />}
+        required
+      />
+
+      {mode === "register" && (
+        <InputGroup
+          type="password"
+          label="Confirm password"
+          placeholder="Re-enter your password"
+          name="confirmPassword"
+          handleChange={handleChange}
+          value={(currentState as RegisterState).confirmPassword}
+          iconPosition="left"
+          icon={<PasswordIcon className="text-dark-4" />}
+          required
+        />
+      )}
+
+      {mode === "login" && (
+        <div className="flex items-center justify-between text-body-sm font-medium">
+          <Checkbox
+            label="Remember me"
+            name="remember"
+            minimal
+            radius="md"
+            withIcon="check"
+            onChange={handleCheckboxChange}
+          />
+
+          <span className="text-dark-4">Forgot password?</span>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        className={cn(
+          "flex w-full items-center justify-center gap-2 rounded-lg bg-primary p-4 font-medium text-white transition hover:bg-opacity-90",
+          loading && "cursor-not-allowed opacity-80",
+        )}
+        disabled={loading}
+      >
+        {mode === "login" ? "Sign in" : "Create account"}
+        {loading && (
+          <span className="inline-block size-4 animate-spin rounded-full border-2 border-solid border-white border-t-transparent" />
+        )}
+      </button>
+    </form>
+  );
+}
+
+export type { AuthFormMode };

--- a/src/components/Auth/AuthForm.tsx
+++ b/src/components/Auth/AuthForm.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { login, register } from "@/services/authService";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { getDefaultRouteForRole } from "@/components/Layouts/sidebar/data";
 
 type AuthFormMode = "login" | "register";
 
@@ -119,7 +120,11 @@ export default function AuthForm({ mode }: AuthFormProps) {
         });
 
         setLoginState(LOGIN_INITIAL_STATE);
-        router.replace("/");
+
+        const role = response.data?.role ?? null;
+        const nextRoute = getDefaultRouteForRole(role);
+
+        router.replace(nextRoute);
         return;
       }
 

--- a/src/components/Auth/Signin/index.tsx
+++ b/src/components/Auth/Signin/index.tsx
@@ -1,32 +1,57 @@
-import Link from "next/link";
-import GoogleSigninButton from "../GoogleSigninButton";
-import SigninWithPassword from "../SigninWithPassword";
+"use client";
+
+import AuthForm, { type AuthFormMode } from "@/components/Auth/AuthForm";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+
+const tabs: { key: AuthFormMode; label: string }[] = [
+  {
+    key: "login",
+    label: "Sign in",
+  },
+  {
+    key: "register",
+    label: "Create account",
+  },
+];
 
 export default function Signin() {
+  const [activeTab, setActiveTab] = useState<AuthFormMode>("login");
+
   return (
-    <>
-      <GoogleSigninButton text="Sign in" />
+    <div>
+      <div className="mb-7 flex flex-col gap-2">
+        <div className="flex gap-2 rounded-lg bg-gray-2 p-1 text-body-sm font-medium dark:bg-dark-3">
+          {tabs.map((tab) => {
+            const isActive = tab.key === activeTab;
 
-      <div className="my-6 flex items-center justify-center">
-        <span className="block h-px w-full bg-stroke dark:bg-dark-3"></span>
-        <div className="block w-full min-w-fit bg-white px-3 text-center font-medium dark:bg-gray-dark">
-          Or sign in with email
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={cn(
+                  "group flex-1 rounded-md px-5 py-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+                  isActive
+                    ? "bg-white shadow-1 dark:bg-dark-2"
+                    : "bg-transparent",
+                )}
+              >
+                <span
+                  className={cn(
+                    "block text-base font-semibold",
+                    isActive ? "text-primary" : "text-dark dark:text-white",
+                  )}
+                >
+                  {tab.label}
+                </span>
+              </button>
+            );
+          })}
         </div>
-        <span className="block h-px w-full bg-stroke dark:bg-dark-3"></span>
       </div>
 
-      <div>
-        <SigninWithPassword />
-      </div>
-
-      <div className="mt-6 text-center">
-        <p>
-          Don’t have any account?{" "}
-          <Link href="/auth/sign-up" className="text-primary">
-            Sign Up
-          </Link>
-        </p>
-      </div>
-    </>
+      <AuthForm mode={activeTab} />
+    </div>
   );
 }

--- a/src/components/Layouts/AppShell.tsx
+++ b/src/components/Layouts/AppShell.tsx
@@ -4,10 +4,12 @@ import { Sidebar } from "@/components/Layouts/sidebar";
 import { Header } from "@/components/Layouts/header";
 import {
   CURRENT_USER_STORAGE_KEY,
+  type CurrentUser,
   getCurrentUser,
 } from "@/services/authService";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState, type PropsWithChildren } from "react";
+import { useEffect, useMemo, useState, type PropsWithChildren } from "react";
+import { getDefaultRouteForRole } from "./sidebar/data";
 
 const AUTH_ROUTE_PREFIXES = ["/login"];
 
@@ -16,15 +18,21 @@ export function AppShell({ children }: PropsWithChildren) {
   const router = useRouter();
   const [hydrated, setHydrated] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
   const isAuthRoute = pathname
     ? AUTH_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
     : false;
+
+  const defaultRoute = useMemo(() => {
+    return getDefaultRouteForRole(currentUser?.role ?? null);
+  }, [currentUser]);
 
   useEffect(() => {
     const user = getCurrentUser();
     const authenticated = Boolean(user);
 
     setIsAuthenticated(authenticated);
+    setCurrentUser(user);
     setHydrated(true);
 
     if (!authenticated && !isAuthRoute) {
@@ -32,10 +40,19 @@ export function AppShell({ children }: PropsWithChildren) {
       return;
     }
 
-    if (authenticated && isAuthRoute) {
-      router.replace("/");
+    if (!user) {
+      return;
     }
-  }, [isAuthRoute, pathname, router]);
+
+    if (isAuthRoute && pathname !== defaultRoute) {
+      router.replace(defaultRoute);
+      return;
+    }
+
+    if (pathname === "/" && pathname !== defaultRoute) {
+      router.replace(defaultRoute);
+    }
+  }, [defaultRoute, isAuthRoute, pathname, router]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -49,9 +66,26 @@ export function AppShell({ children }: PropsWithChildren) {
       const authenticated = Boolean(user);
 
       setIsAuthenticated(authenticated);
+      setCurrentUser(user);
 
       if (!authenticated && !isAuthRoute) {
         router.replace("/login");
+        return;
+      }
+
+      if (!user) {
+        return;
+      }
+
+      const nextDefaultRoute = getDefaultRouteForRole(user.role);
+
+      if (isAuthRoute && pathname !== nextDefaultRoute) {
+        router.replace(nextDefaultRoute);
+        return;
+      }
+
+      if (pathname === "/" && pathname !== nextDefaultRoute) {
+        router.replace(nextDefaultRoute);
       }
     };
 
@@ -60,7 +94,7 @@ export function AppShell({ children }: PropsWithChildren) {
     return () => {
       window.removeEventListener("storage", handleStorage);
     };
-  }, [isAuthRoute, router]);
+  }, [isAuthRoute, pathname, router]);
 
   if (isAuthRoute) {
     return <>{children}</>;

--- a/src/components/Layouts/AppShell.tsx
+++ b/src/components/Layouts/AppShell.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Sidebar } from "@/components/Layouts/sidebar";
+import { Header } from "@/components/Layouts/header";
+import {
+  CURRENT_USER_STORAGE_KEY,
+  getCurrentUser,
+} from "@/services/authService";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState, type PropsWithChildren } from "react";
+
+const AUTH_ROUTE_PREFIXES = ["/login"];
+
+export function AppShell({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [hydrated, setHydrated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const isAuthRoute = pathname
+    ? AUTH_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+    : false;
+
+  useEffect(() => {
+    const user = getCurrentUser();
+    const authenticated = Boolean(user);
+
+    setIsAuthenticated(authenticated);
+    setHydrated(true);
+
+    if (!authenticated && !isAuthRoute) {
+      router.replace("/login");
+      return;
+    }
+
+    if (authenticated && isAuthRoute) {
+      router.replace("/");
+    }
+  }, [isAuthRoute, pathname, router]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== CURRENT_USER_STORAGE_KEY) {
+        return;
+      }
+
+      const user = getCurrentUser();
+      const authenticated = Boolean(user);
+
+      setIsAuthenticated(authenticated);
+
+      if (!authenticated && !isAuthRoute) {
+        router.replace("/login");
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, [isAuthRoute, router]);
+
+  if (isAuthRoute) {
+    return <>{children}</>;
+  }
+
+  if (!hydrated) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+
+      <div className="w-full bg-gray-2 dark:bg-[#020d1a]">
+        <Header />
+
+        <main className="isolate mx-auto w-full max-w-screen-2xl overflow-hidden p-4 md:p-6 2xl:p-10">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layouts/header/index.tsx
+++ b/src/components/Layouts/header/index.tsx
@@ -1,11 +1,8 @@
 "use client";
-
-import { SearchIcon } from "@/assets/icons";
 import Image from "next/image";
 import Link from "next/link";
 import { useSidebarContext } from "../sidebar/sidebar-context";
 import { MenuIcon } from "./icons";
-import { Notification } from "./notification";
 import { ThemeToggleSwitch } from "./theme-toggle";
 import { UserInfo } from "./user-info";
 
@@ -42,19 +39,7 @@ export function Header() {
       </div>
 
       <div className="flex flex-1 items-center justify-end gap-2 min-[375px]:gap-4">
-        <div className="relative w-full max-w-[300px]">
-          <input
-            type="search"
-            placeholder="Search"
-            className="flex w-full items-center gap-3.5 rounded-full border bg-gray-2 py-3 pl-[53px] pr-5 outline-none transition-colors focus-visible:border-primary dark:border-dark-3 dark:bg-dark-2 dark:hover:border-dark-4 dark:hover:bg-dark-3 dark:hover:text-dark-6 dark:focus-visible:border-primary"
-          />
-
-          <SearchIcon className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 max-[1015px]:size-5" />
-        </div>
-
         <ThemeToggleSwitch />
-
-        <Notification />
 
         <div className="shrink-0">
           <UserInfo />

--- a/src/components/Layouts/header/user-info/index.tsx
+++ b/src/components/Layouts/header/user-info/index.tsx
@@ -6,18 +6,56 @@ import {
   DropdownContent,
   DropdownTrigger,
 } from "@/components/ui/dropdown";
+import {
+  CURRENT_USER_STORAGE_KEY,
+  getCurrentUser,
+  logout,
+  type CurrentUser,
+} from "@/services/authService";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
-import Link from "next/link";
-import { useState } from "react";
-import { LogOutIcon, SettingsIcon, UserIcon } from "./icons";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { LogOutIcon } from "./icons";
 
 export function UserInfo() {
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(
+    () => getCurrentUser(),
+  );
+
+  useEffect(() => {
+    setCurrentUser(getCurrentUser());
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== CURRENT_USER_STORAGE_KEY) {
+        return;
+      }
+
+      setCurrentUser(getCurrentUser());
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  const displayName = currentUser?.username ?? "Guest";
+
+  const handleLogout = () => {
+    logout();
+    setCurrentUser(null);
+    setIsOpen(false);
+    router.replace("/login");
+  };
 
   const USER = {
-    name: "John Smith",
-    email: "johnson@nextadmin.com",
+    name: displayName,
     img: "/images/user/user-03.png",
   };
 
@@ -71,42 +109,18 @@ export function UserInfo() {
               {USER.name}
             </div>
 
-            <div className="leading-none text-gray-6">{USER.email}</div>
+            <div className="leading-none text-gray-6">
+              {currentUser ? (currentUser.role === "admin" ? "Admin" : "User") : "Not signed in"}
+            </div>
           </figcaption>
         </figure>
-
-        <hr className="border-[#E8E8E8] dark:border-dark-3" />
-
-        <div className="p-2 text-base text-[#4B5563] dark:text-dark-6 [&>*]:cursor-pointer">
-          <Link
-            href={"/profile"}
-            onClick={() => setIsOpen(false)}
-            className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-[9px] hover:bg-gray-2 hover:text-dark dark:hover:bg-dark-3 dark:hover:text-white"
-          >
-            <UserIcon />
-
-            <span className="mr-auto text-base font-medium">View profile</span>
-          </Link>
-
-          <Link
-            href={"/pages/settings"}
-            onClick={() => setIsOpen(false)}
-            className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-[9px] hover:bg-gray-2 hover:text-dark dark:hover:bg-dark-3 dark:hover:text-white"
-          >
-            <SettingsIcon />
-
-            <span className="mr-auto text-base font-medium">
-              Account Settings
-            </span>
-          </Link>
-        </div>
 
         <hr className="border-[#E8E8E8] dark:border-dark-3" />
 
         <div className="p-2 text-base text-[#4B5563] dark:text-dark-6">
           <button
             className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-[9px] hover:bg-gray-2 hover:text-dark dark:hover:bg-dark-3 dark:hover:text-white"
-            onClick={() => setIsOpen(false)}
+            onClick={handleLogout}
           >
             <LogOutIcon />
 

--- a/src/components/Layouts/sidebar/data/index.ts
+++ b/src/components/Layouts/sidebar/data/index.ts
@@ -1,105 +1,83 @@
+import type { PropsType as IconProps } from "../icons";
 import * as Icons from "../icons";
 
-export const NAV_DATA = [
+export type SidebarSubItem = {
+  title: string;
+  url: string;
+};
+
+export type SidebarItem = {
+  title: string;
+  icon: (props: IconProps) => JSX.Element;
+  url?: string;
+  items: SidebarSubItem[];
+};
+
+export type SidebarSection = {
+  label: string;
+  items: SidebarItem[];
+};
+
+const USER_SECTIONS: SidebarSection[] = [
   {
-    label: "MAIN MENU",
+    label: "SERVICES",
     items: [
       {
-        title: "Dashboard",
-        icon: Icons.HomeIcon,
-        items: [
-          {
-            title: "eCommerce",
-            url: "/",
-          },
-        ],
-      },
-      {
-        title: "Calendar",
-        url: "/calendar",
-        icon: Icons.Calendar,
-        items: [],
-      },
-      {
-        title: "Profile",
-        url: "/profile",
-        icon: Icons.User,
-        items: [],
-      },
-      {
-        title: "Forms",
-        icon: Icons.Alphabet,
-        items: [
-          {
-            title: "Form Elements",
-            url: "/forms/form-elements",
-          },
-          {
-            title: "Form Layout",
-            url: "/forms/form-layout",
-          },
-        ],
-      },
-      {
-        title: "Tables",
-        url: "/tables",
-        icon: Icons.Table,
-        items: [
-          {
-            title: "Tables",
-            url: "/tables",
-          },
-        ],
-      },
-      {
-        title: "Pages",
-        icon: Icons.Alphabet,
-        items: [
-          {
-            title: "Settings",
-            url: "/pages/settings",
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "OTHERS",
-    items: [
-      {
-        title: "Charts",
-        icon: Icons.PieChart,
-        items: [
-          {
-            title: "Basic Chart",
-            url: "/charts/basic-chart",
-          },
-        ],
-      },
-      {
-        title: "UI Elements",
+        title: "Feedback Service",
         icon: Icons.FourCircle,
-        items: [
-          {
-            title: "Alerts",
-            url: "/ui-elements/alerts",
-          },
-          {
-            title: "Buttons",
-            url: "/ui-elements/buttons",
-          },
-        ],
+        url: "/feedback",
+        items: [],
       },
       {
-        title: "Authentication",
-        icon: Icons.Authentication,
-        items: [
-          {
-            title: "Sign In",
-            url: "/auth/sign-in",
-          },
-        ],
+        title: "Booking Service",
+        icon: Icons.Calendar,
+        url: "/booking",
+        items: [],
+      },
+      {
+        title: "Document Request Service",
+        icon: Icons.Table,
+        url: "/documents",
+        items: [],
       },
     ],
   },
 ];
+
+const ADMIN_SECTIONS: SidebarSection[] = [
+  {
+    label: "APPROVALS",
+    items: [
+      {
+        title: "Feedback Service Approvals",
+        icon: Icons.FourCircle,
+        url: "/approvals/feedback",
+        items: [],
+      },
+      {
+        title: "Booking Service Approvals",
+        icon: Icons.Calendar,
+        url: "/approvals/booking",
+        items: [],
+      },
+      {
+        title: "Document Service Approvals",
+        icon: Icons.Table,
+        url: "/approvals/documents",
+        items: [],
+      },
+    ],
+  },
+];
+
+export function buildSidebarSections(role: "admin" | "user" | null): SidebarSection[] {
+  if (role === "admin") {
+    return ADMIN_SECTIONS;
+  }
+
+  if (role === "user") {
+    return USER_SECTIONS;
+  }
+
+  return [];
+}

--- a/src/components/Layouts/sidebar/data/index.ts
+++ b/src/components/Layouts/sidebar/data/index.ts
@@ -18,6 +18,24 @@ export type SidebarSection = {
   items: SidebarItem[];
 };
 
+function findFirstUrl(sections: SidebarSection[]): string | null {
+  for (const section of sections) {
+    for (const item of section.items) {
+      if (item.url) {
+        return item.url;
+      }
+
+      const nestedUrl = item.items.find((subItem) => subItem.url)?.url;
+
+      if (nestedUrl) {
+        return nestedUrl;
+      }
+    }
+  }
+
+  return null;
+}
+
 const USER_SECTIONS: SidebarSection[] = [
   {
     label: "SERVICES",
@@ -80,4 +98,18 @@ export function buildSidebarSections(role: "admin" | "user" | null): SidebarSect
   }
 
   return [];
+}
+
+export function getDefaultRouteForRole(
+  role: "admin" | "user" | null,
+): string {
+  if (role === "admin") {
+    return findFirstUrl(ADMIN_SECTIONS) ?? "/";
+  }
+
+  if (role === "user") {
+    return findFirstUrl(USER_SECTIONS) ?? "/";
+  }
+
+  return "/";
 }

--- a/src/components/Layouts/sidebar/index.tsx
+++ b/src/components/Layouts/sidebar/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { CURRENT_USER_STORAGE_KEY, getCurrentUser } from "@/services/authService";
 import {
   buildSidebarSections,
+  getDefaultRouteForRole,
   type SidebarSection,
 } from "./data";
 import { ArrowLeftIcon, ChevronUp } from "./icons";
@@ -21,6 +22,10 @@ export function Sidebar() {
   const [sections, setSections] = useState<SidebarSection[]>(() => {
     const currentUser = getCurrentUser();
     return buildSidebarSections(currentUser?.role ?? null);
+  });
+  const [defaultRoute, setDefaultRoute] = useState<string>(() => {
+    const currentUser = getCurrentUser();
+    return getDefaultRouteForRole(currentUser?.role ?? null);
   });
 
   const storageKeys = useMemo(() => {
@@ -58,7 +63,10 @@ export function Sidebar() {
   useEffect(() => {
     const syncSections = () => {
       const currentUser = getCurrentUser();
-      setSections(buildSidebarSections(currentUser?.role ?? null));
+      const role = currentUser?.role ?? null;
+
+      setSections(buildSidebarSections(role));
+      setDefaultRoute(getDefaultRouteForRole(role));
     };
 
     syncSections();
@@ -110,7 +118,7 @@ export function Sidebar() {
         <div className="flex h-full flex-col py-10 pl-[25px] pr-[7px]">
           <div className="relative pr-4.5">
             <Link
-              href={"/"}
+              href={defaultRoute}
               onClick={() => isMobile && toggleSidebar()}
               className="px-0 py-2.5 min-[850px]:py-0"
             >

--- a/src/components/Layouts/sidebar/index.tsx
+++ b/src/components/Layouts/sidebar/index.tsx
@@ -4,8 +4,12 @@ import { Logo } from "@/components/logo";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
-import { NAV_DATA } from "./data";
+import { useEffect, useMemo, useState } from "react";
+import { CURRENT_USER_STORAGE_KEY, getCurrentUser } from "@/services/authService";
+import {
+  buildSidebarSections,
+  type SidebarSection,
+} from "./data";
 import { ArrowLeftIcon, ChevronUp } from "./icons";
 import { MenuItem } from "./menu-item";
 import { useSidebarContext } from "./sidebar-context";
@@ -14,19 +18,26 @@ export function Sidebar() {
   const pathname = usePathname();
   const { setIsOpen, isOpen, isMobile, toggleSidebar } = useSidebarContext();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
+  const [sections, setSections] = useState<SidebarSection[]>(() => {
+    const currentUser = getCurrentUser();
+    return buildSidebarSections(currentUser?.role ?? null);
+  });
+
+  const storageKeys = useMemo(() => {
+    return [CURRENT_USER_STORAGE_KEY];
+  }, []);
 
   const toggleExpanded = (title: string) => {
     setExpandedItems((prev) => (prev.includes(title) ? [] : [title]));
-
-    // Uncomment the following line to enable multiple expanded items
-    // setExpandedItems((prev) =>
-    //   prev.includes(title) ? prev.filter((t) => t !== title) : [...prev, title],
-    // );
   };
 
   useEffect(() => {
-    // Keep collapsible open, when it's subpage is active
-    NAV_DATA.some((section) => {
+    setExpandedItems([]);
+  }, [sections]);
+
+  useEffect(() => {
+    // Keep collapsible open when subpage is active
+    sections.some((section) => {
       return section.items.some((item) => {
         return item.items.some((subItem) => {
           if (subItem.url === pathname) {
@@ -37,10 +48,43 @@ export function Sidebar() {
             // Break the loop
             return true;
           }
+
+          return false;
         });
       });
     });
-  }, [pathname]);
+  }, [expandedItems, pathname, sections]);
+
+  useEffect(() => {
+    const syncSections = () => {
+      const currentUser = getCurrentUser();
+      setSections(buildSidebarSections(currentUser?.role ?? null));
+    };
+
+    syncSections();
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && !storageKeys.includes(event.key)) {
+        return;
+      }
+
+      syncSections();
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, [storageKeys]);
+
+  if (!sections.length) {
+    return null;
+  }
 
   return (
     <>
@@ -87,7 +131,7 @@ export function Sidebar() {
 
           {/* Navigation */}
           <div className="custom-scrollbar mt-6 flex-1 overflow-y-auto pr-3 min-[850px]:mt-10">
-            {NAV_DATA.map((section) => (
+            {sections.map((section) => (
               <div key={section.label} className="mb-6">
                 <h2 className="mb-5 text-sm font-medium text-dark-4 dark:text-dark-6">
                   {section.label}
@@ -115,8 +159,7 @@ export function Sidebar() {
                               <ChevronUp
                                 className={cn(
                                   "ml-auto rotate-180 transition-transform duration-200",
-                                  expandedItems.includes(item.title) &&
-                                    "rotate-0",
+                                  expandedItems.includes(item.title) && "rotate-0",
                                 )}
                                 aria-hidden="true"
                               />
@@ -143,11 +186,7 @@ export function Sidebar() {
                           </div>
                         ) : (
                           (() => {
-                            const href =
-                              "url" in item
-                                ? item.url + ""
-                                : "/" +
-                                  item.title.toLowerCase().split(" ").join("-");
+                            const href = item.url ?? "/";
 
                             return (
                               <MenuItem

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,27 +1,9 @@
-import darkLogo from "@/assets/logos/dark.svg";
-import logo from "@/assets/logos/main.svg";
-import Image from "next/image";
-
 export function Logo() {
   return (
-    <div className="relative h-8 max-w-[10.847rem]">
-      <Image
-        src={logo}
-        fill
-        className="dark:hidden"
-        alt="NextAdmin logo"
-        role="presentation"
-        quality={100}
-      />
-
-      <Image
-        src={darkLogo}
-        fill
-        className="hidden dark:block"
-        alt="NextAdmin logo"
-        role="presentation"
-        quality={100}
-      />
+    <div className="flex items-center" aria-label="collection-services logo">
+      <span className="text-xl font-semibold lowercase tracking-tight text-black transition-colors dark:text-white">
+        collection-services
+      </span>
     </div>
   );
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,195 @@
+"use client";
+
+export interface AuthApiResponse<T = unknown> {
+  message: string;
+  data?: T;
+}
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+  remember?: boolean;
+}
+
+export interface RegisterRequest {
+  username: string;
+  password: string;
+}
+
+export type StoredUser = {
+  username: string;
+  password: string;
+  role: "admin" | "user";
+  createdAt: string;
+};
+
+export type CurrentUser = {
+  username: string;
+  role: "admin" | "user";
+  loggedInAt: string;
+  remember: boolean;
+};
+
+const USERS_STORAGE_KEY = "collection-services.users";
+const CURRENT_USER_STORAGE_KEY = "collection-services.current-user";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readFromStorage<T>(key: string, fallback: T): T {
+  if (!isBrowser()) {
+    return fallback;
+  }
+
+  const rawValue = window.localStorage.getItem(key);
+
+  if (!rawValue) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(rawValue) as T;
+  } catch (error) {
+    console.warn(`Failed to parse localStorage value for key "${key}"`, error);
+    return fallback;
+  }
+}
+
+function writeToStorage<T>(key: string, value: T): void {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function removeFromStorage(key: string): void {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.removeItem(key);
+}
+
+function getStoredUsers(): StoredUser[] {
+  return readFromStorage<StoredUser[]>(USERS_STORAGE_KEY, []);
+}
+
+function persistUsers(users: StoredUser[]): void {
+  writeToStorage(USERS_STORAGE_KEY, users);
+}
+
+function normalizeUsername(username: string): string {
+  return username.trim();
+}
+
+function determineRole(username: string): "admin" | "user" {
+  return username.toLowerCase().includes("admin") ? "admin" : "user";
+}
+
+function findUserByUsername(
+  users: StoredUser[],
+  username: string,
+): StoredUser | undefined {
+  const normalizedUsername = username.trim().toLowerCase();
+
+  return users.find(
+    (user) => user.username.toLowerCase() === normalizedUsername,
+  );
+}
+
+function setCurrentUser(user: CurrentUser): void {
+  writeToStorage(CURRENT_USER_STORAGE_KEY, user);
+}
+
+export function getCurrentUser(): CurrentUser | null {
+  return readFromStorage<CurrentUser | null>(CURRENT_USER_STORAGE_KEY, null);
+}
+
+export function logout(): void {
+  removeFromStorage(CURRENT_USER_STORAGE_KEY);
+}
+
+export async function register({
+  username,
+  password,
+}: RegisterRequest): Promise<AuthApiResponse<{ username: string; role: "admin" | "user" }>> {
+  const normalizedUsername = normalizeUsername(username);
+
+  if (!normalizedUsername) {
+    throw new Error("Username is required.");
+  }
+
+  if (!password) {
+    throw new Error("Password is required.");
+  }
+
+  const users = getStoredUsers();
+
+  const duplicateUser = users.find(
+    (user) => user.username.toLowerCase() === normalizedUsername.toLowerCase(),
+  );
+
+  if (duplicateUser) {
+    throw new Error("An account with that username already exists.");
+  }
+
+  const role = determineRole(normalizedUsername);
+
+  const newUser: StoredUser = {
+    username: normalizedUsername,
+    password,
+    role,
+    createdAt: new Date().toISOString(),
+  };
+
+  persistUsers([...users, newUser]);
+
+  return {
+    message:
+      role === "admin"
+        ? "Admin account created successfully."
+        : "Account created successfully.",
+    data: {
+      username: newUser.username,
+      role: newUser.role,
+    },
+  };
+}
+
+export async function login({
+  username,
+  password,
+  remember = false,
+}: LoginRequest): Promise<AuthApiResponse<CurrentUser>> {
+  const users = getStoredUsers();
+  const user = findUserByUsername(users, username);
+
+  if (!user) {
+    throw new Error("Account not found. Please register first.");
+  }
+
+  if (user.password !== password) {
+    throw new Error("Incorrect password. Please try again.");
+  }
+
+  const currentUser: CurrentUser = {
+    username: user.username,
+    role: user.role,
+    loggedInAt: new Date().toISOString(),
+    remember: Boolean(remember),
+  };
+
+  setCurrentUser(currentUser);
+
+  return {
+    message:
+      user.role === "admin"
+        ? "Welcome back, admin."
+        : "Signed in successfully.",
+    data: currentUser,
+  };
+}
+
+export { USERS_STORAGE_KEY, CURRENT_USER_STORAGE_KEY };

--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import type { CurrentUser } from "@/services/authService";
+
+export type SubmissionType = "feedback" | "booking" | "document";
+
+export type SubmissionStatus = "pending" | "approved" | "rejected";
+
+export interface FeedbackPayload {
+  subject: string;
+  details: string;
+  contactMethod?: string;
+}
+
+export interface BookingPayload {
+  serviceName: string;
+  preferredDate: string;
+  preferredTime: string;
+  notes?: string;
+}
+
+export interface DocumentPayload {
+  documentType: string;
+  justification: string;
+  requiredBy?: string;
+}
+
+export type SubmissionPayloadMap = {
+  feedback: FeedbackPayload;
+  booking: BookingPayload;
+  document: DocumentPayload;
+};
+
+export interface SubmissionRecord<T extends SubmissionType> {
+  id: string;
+  type: T;
+  payload: SubmissionPayloadMap[T];
+  status: SubmissionStatus;
+  submittedBy: string;
+  createdAt: string;
+  decisionBy?: string;
+  decidedAt?: string;
+}
+
+const STORAGE_KEYS: Record<SubmissionType, string> = {
+  feedback: "collection-services.feedback-submissions",
+  booking: "collection-services.booking-submissions",
+  document: "collection-services.document-submissions",
+};
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readFromStorage<T>(key: string, fallback: T): T {
+  if (!isBrowser()) {
+    return fallback;
+  }
+
+  const rawValue = window.localStorage.getItem(key);
+
+  if (!rawValue) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(rawValue) as T;
+  } catch (error) {
+    console.warn(`Unable to parse submissions for key "${key}"`, error);
+    return fallback;
+  }
+}
+
+function writeToStorage<T>(key: string, value: T): void {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function buildIdentifier(type: SubmissionType): string {
+  const fallback = `${type}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+  if (typeof crypto === "undefined" || typeof crypto.randomUUID !== "function") {
+    return fallback;
+  }
+
+  return `${type}-${crypto.randomUUID()}`;
+}
+
+function getAllSubmissions<T extends SubmissionType>(type: T): SubmissionRecord<T>[] {
+  return readFromStorage<SubmissionRecord<T>[]>(STORAGE_KEYS[type], []);
+}
+
+function persistSubmissions<T extends SubmissionType>(
+  type: T,
+  submissions: SubmissionRecord<T>[],
+): void {
+  writeToStorage(STORAGE_KEYS[type], submissions);
+}
+
+function requireUser(user: CurrentUser | null): asserts user is CurrentUser {
+  if (!user) {
+    throw new Error("You must be signed in to submit a request.");
+  }
+}
+
+export function getSubmissionStorageKey(type: SubmissionType): string {
+  return STORAGE_KEYS[type];
+}
+
+export function listSubmissions<T extends SubmissionType>(type: T): SubmissionRecord<T>[] {
+  return getAllSubmissions(type);
+}
+
+export function listSubmissionsForUser<T extends SubmissionType>(
+  type: T,
+  username: string,
+): SubmissionRecord<T>[] {
+  return getAllSubmissions(type).filter(
+    (submission) => submission.submittedBy.toLowerCase() === username.toLowerCase(),
+  );
+}
+
+export function createSubmission<T extends SubmissionType>(
+  type: T,
+  payload: SubmissionPayloadMap[T],
+  user: CurrentUser | null,
+): SubmissionRecord<T> {
+  requireUser(user);
+
+  const submissions = getAllSubmissions(type);
+  const now = new Date().toISOString();
+
+  const newSubmission: SubmissionRecord<T> = {
+    id: buildIdentifier(type),
+    type,
+    payload,
+    status: "pending",
+    submittedBy: user.username,
+    createdAt: now,
+  };
+
+  persistSubmissions(type, [...submissions, newSubmission]);
+
+  return newSubmission;
+}
+
+export function updateSubmissionStatus<T extends SubmissionType>(
+  type: T,
+  id: string,
+  status: Exclude<SubmissionStatus, "pending">,
+  decisionBy: CurrentUser | null,
+): SubmissionRecord<T> {
+  requireUser(decisionBy);
+
+  if (decisionBy.role !== "admin") {
+    throw new Error("Only administrators can update submission status.");
+  }
+
+  const submissions = getAllSubmissions(type);
+
+  const submissionIndex = submissions.findIndex((submission) => submission.id === id);
+
+  if (submissionIndex === -1) {
+    throw new Error("Submission could not be found.");
+  }
+
+  const now = new Date().toISOString();
+
+  const updatedSubmission: SubmissionRecord<T> = {
+    ...submissions[submissionIndex],
+    status,
+    decisionBy: decisionBy.username,
+    decidedAt: now,
+  };
+
+  const nextSubmissions = [...submissions];
+  nextSubmissions.splice(submissionIndex, 1, updatedSubmission);
+
+  persistSubmissions(type, nextSubmissions);
+
+  return updatedSubmission;
+}


### PR DESCRIPTION
## Summary
- hide the global header search input to simplify the top bar
- add reusable approval table helpers with view-details toggles for pending submissions
- extend each admin approval page with detailed payload sections for feedback, booking, and document requests

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d91d9e2ad48323bbfc1d3441105137