### PR TITLE
Update service flows for localized applications

### DIFF
--- a/src/app/approvals/booking/page.tsx
+++ b/src/app/approvals/booking/page.tsx
@@ -21,12 +21,12 @@ function formatSchedule(submission: any): string {
 
 const BookingApprovalPage = createApprovalPage({
   type: "booking",
-  title: "医疗证明申请审核",
-  description: "审核用户提交的医疗证明申请，确认预约时间和用途说明后再做决定。",
-  emptyLabel: "当前没有待审核的医疗证明申请。",
+  title: "Medical Certificate Application Reviews",
+  description: "Review medical certificate applications and verify the requested schedule and purpose before making a decision.",
+  emptyLabel: "There are no medical certificate applications awaiting review.",
   columns: [
     {
-      header: "患者信息",
+      header: "Patient Details",
       render: (submission) => {
         const name = submission.payload.patientName ?? submission.payload.serviceName ?? "—";
         const purpose =
@@ -35,28 +35,28 @@ const BookingApprovalPage = createApprovalPage({
         return (
           <div className="space-y-1">
             <p className="font-medium text-gray-900 dark:text-gray-100">{name}</p>
-            <p className="text-xs text-gray-600 dark:text-gray-300 break-words">用途：{purpose}</p>
+            <p className="text-xs text-gray-600 dark:text-gray-300 break-words">Purpose: {purpose}</p>
           </div>
         );
       },
     },
     {
-      header: "预约时间",
+      header: "Appointment Slot",
       className: "whitespace-nowrap",
       render: (submission) => formatSchedule(submission),
     },
     {
-      header: "提交账号",
+      header: "Submitted By",
       className: "whitespace-nowrap",
       render: (submission) => submission.submittedBy,
     },
     {
-      header: "提交时间",
+      header: "Submitted",
       className: "whitespace-nowrap",
       render: (submission) => new Date(submission.createdAt).toLocaleString(),
     },
     {
-      header: "状态",
+      header: "Status",
       className: "whitespace-nowrap",
       render: (submission) => (
         <span className="capitalize text-gray-900 dark:text-gray-100">
@@ -69,38 +69,38 @@ const BookingApprovalPage = createApprovalPage({
     return (
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">患者姓名</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Patient Name</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {submission.payload.patientName ?? submission.payload.serviceName ?? "—"}
           </p>
         </div>
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">预约时间</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Appointment Slot</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">{formatSchedule(submission)}</p>
         </div>
         <div className="space-y-1 md:col-span-2">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">用途说明</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Purpose</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {submission.payload.certificatePurpose ?? submission.payload.notes ?? "—"}
           </p>
         </div>
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交账号</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted By</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
         </div>
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交时间</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {new Date(submission.createdAt).toLocaleString()}
           </p>
         </div>
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">状态</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
           <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
         </div>
         {submission.decisionBy ? (
           <div className="space-y-1">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">审核人</h3>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewer</h3>
             <p className="text-sm text-gray-700 dark:text-gray-300">
               {submission.decisionBy}
               {submission.decidedAt

--- a/src/app/approvals/booking/page.tsx
+++ b/src/app/approvals/booking/page.tsx
@@ -2,43 +2,61 @@
 
 import { createApprovalPage } from "../_components/createApprovalPage";
 
+function formatSchedule(submission: any): string {
+  const date =
+    submission.payload.appointmentDate ?? submission.payload.preferredDate ?? "";
+  const time =
+    submission.payload.appointmentTime ?? submission.payload.preferredTime ?? "";
+
+  if (!date) {
+    return "—";
+  }
+
+  try {
+    return new Date(`${date}T${time || "00:00"}`).toLocaleString();
+  } catch (error) {
+    return `${date} ${time}`.trim();
+  }
+}
+
 const BookingApprovalPage = createApprovalPage({
   type: "booking",
-  title: "Booking Service Approvals",
-  description:
-    "Review appointment requests from users and confirm whether the requested slot can be honored.",
-  emptyLabel: "There are no booking requests waiting for approval.",
+  title: "医疗证明申请审核",
+  description: "审核用户提交的医疗证明申请，确认预约时间和用途说明后再做决定。",
+  emptyLabel: "当前没有待审核的医疗证明申请。",
   columns: [
     {
-      header: "Request",
-      render: (submission) => (
-        <div className="space-y-1">
-          <p className="font-medium text-gray-900 dark:text-gray-100">
-            {submission.payload.serviceName}
-          </p>
-          {submission.payload.notes ? (
-            <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
-              {submission.payload.notes}
-            </p>
-          ) : null}
-        </div>
-      ),
+      header: "患者信息",
+      render: (submission) => {
+        const name = submission.payload.patientName ?? submission.payload.serviceName ?? "—";
+        const purpose =
+          submission.payload.certificatePurpose ?? submission.payload.notes ?? "—";
+
+        return (
+          <div className="space-y-1">
+            <p className="font-medium text-gray-900 dark:text-gray-100">{name}</p>
+            <p className="text-xs text-gray-600 dark:text-gray-300 break-words">用途：{purpose}</p>
+          </div>
+        );
+      },
     },
     {
-      header: "Preferred slot",
+      header: "预约时间",
       className: "whitespace-nowrap",
-      render: (submission) =>
-        new Date(
-          `${submission.payload.preferredDate}T${submission.payload.preferredTime || "00:00"}`,
-        ).toLocaleString(),
+      render: (submission) => formatSchedule(submission),
     },
     {
-      header: "Requested by",
+      header: "提交账号",
       className: "whitespace-nowrap",
       render: (submission) => submission.submittedBy,
     },
     {
-      header: "Status",
+      header: "提交时间",
+      className: "whitespace-nowrap",
+      render: (submission) => new Date(submission.createdAt).toLocaleString(),
+    },
+    {
+      header: "状态",
       className: "whitespace-nowrap",
       render: (submission) => (
         <span className="capitalize text-gray-900 dark:text-gray-100">
@@ -47,49 +65,53 @@ const BookingApprovalPage = createApprovalPage({
       ),
     },
   ],
-  renderDetails: (submission) => (
-    <div className="grid gap-4 md:grid-cols-2">
-      <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Service</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.serviceName}</p>
-      </div>
-      <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Preferred schedule</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">
-          {new Date(`${submission.payload.preferredDate}T${submission.payload.preferredTime || "00:00"}`).toLocaleString()}
-        </p>
-      </div>
-      {submission.payload.notes ? (
-        <div className="space-y-1 md:col-span-2">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Additional notes</h3>
-          <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.notes}</p>
-        </div>
-      ) : null}
-      <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Requested by</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
-      </div>
-      <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">{new Date(submission.createdAt).toLocaleString()}</p>
-      </div>
-      <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
-        <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
-      </div>
-      {submission.decisionBy ? (
+  renderDetails: (submission) => {
+    return (
+      <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewed by</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">患者姓名</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
-            {submission.decisionBy}
-            {submission.decidedAt
-              ? ` · ${new Date(submission.decidedAt).toLocaleString()}`
-              : ""}
+            {submission.payload.patientName ?? submission.payload.serviceName ?? "—"}
           </p>
         </div>
-      ) : null}
-    </div>
-  ),
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">预约时间</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{formatSchedule(submission)}</p>
+        </div>
+        <div className="space-y-1 md:col-span-2">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">用途说明</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {submission.payload.certificatePurpose ?? submission.payload.notes ?? "—"}
+          </p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交账号</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交时间</h3>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {new Date(submission.createdAt).toLocaleString()}
+          </p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">状态</h3>
+          <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
+        </div>
+        {submission.decisionBy ? (
+          <div className="space-y-1">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">审核人</h3>
+            <p className="text-sm text-gray-700 dark:text-gray-300">
+              {submission.decisionBy}
+              {submission.decidedAt
+                ? ` · ${new Date(submission.decidedAt).toLocaleString()}`
+                : ""}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    );
+  },
 });
 
 export default BookingApprovalPage;

--- a/src/app/approvals/documents/page.tsx
+++ b/src/app/approvals/documents/page.tsx
@@ -2,41 +2,57 @@
 
 import { createApprovalPage } from "../_components/createApprovalPage";
 
+function formatOptionalDate(value: string | undefined | null): string {
+  if (!value) {
+    return "未填写";
+  }
+
+  try {
+    return new Date(`${value}T00:00`).toLocaleDateString();
+  } catch (error) {
+    return value;
+  }
+}
+
 const DocumentApprovalPage = createApprovalPage({
   type: "document",
-  title: "Document Service Approvals",
-  description:
-    "Review document requests submitted by users and confirm whether the requested materials can be issued.",
-  emptyLabel: "There are no document requests waiting for approval.",
+  title: "退税申请审核",
+  description: "审核用户提交的退税申请，确认纳税信息与退款原因后再进行处理。",
+  emptyLabel: "当前没有待审核的退税申请。",
   columns: [
     {
-      header: "Document",
+      header: "纳税人",
       render: (submission) => (
         <div className="space-y-1">
           <p className="font-medium text-gray-900 dark:text-gray-100">
-            {submission.payload.documentType}
+            {submission.payload.taxpayerName ?? submission.payload.documentType ?? "—"}
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
-            {submission.payload.justification}
+            原因：{submission.payload.refundReason ?? submission.payload.justification ?? "—"}
           </p>
         </div>
       ),
     },
     {
-      header: "Needed by",
+      header: "申请年份",
       className: "whitespace-nowrap",
-      render: (submission) =>
-        submission.payload.requiredBy
-          ? new Date(`${submission.payload.requiredBy}T00:00`).toLocaleDateString()
-          : "Not specified",
+      render: (submission) => submission.payload.taxYear ?? "—",
     },
     {
-      header: "Requested by",
+      header: "预计到账日期",
+      className: "whitespace-nowrap",
+      render: (submission) =>
+        formatOptionalDate(
+          submission.payload.expectedPayoutDate ?? submission.payload.requiredBy,
+        ),
+    },
+    {
+      header: "提交账号",
       className: "whitespace-nowrap",
       render: (submission) => submission.submittedBy,
     },
     {
-      header: "Status",
+      header: "状态",
       className: "whitespace-nowrap",
       render: (submission) => (
         <span className="capitalize text-gray-900 dark:text-gray-100">
@@ -48,36 +64,46 @@ const DocumentApprovalPage = createApprovalPage({
   renderDetails: (submission) => (
     <div className="grid gap-4 md:grid-cols-2">
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Document</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.documentType}</p>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">纳税人</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {submission.payload.taxpayerName ?? submission.payload.documentType ?? "—"}
+        </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Needed by</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">申请年份</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
-          {submission.payload.requiredBy
-            ? new Date(`${submission.payload.requiredBy}T00:00`).toLocaleDateString()
-            : "Not specified"}
+          {submission.payload.taxYear ?? "—"}
         </p>
       </div>
       <div className="space-y-1 md:col-span-2">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Justification</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.justification}</p>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">退款原因</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {submission.payload.refundReason ?? submission.payload.justification ?? "—"}
+        </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Requested by</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">预计到账日期</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {formatOptionalDate(
+            submission.payload.expectedPayoutDate ?? submission.payload.requiredBy,
+          )}
+        </p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交账号</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交时间</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">{new Date(submission.createdAt).toLocaleString()}</p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">状态</h3>
         <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
       </div>
       {submission.decisionBy ? (
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewed by</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">审核人</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {submission.decisionBy}
             {submission.decidedAt

--- a/src/app/approvals/documents/page.tsx
+++ b/src/app/approvals/documents/page.tsx
@@ -4,7 +4,7 @@ import { createApprovalPage } from "../_components/createApprovalPage";
 
 function formatOptionalDate(value: string | undefined | null): string {
   if (!value) {
-    return "未填写";
+    return "Not provided";
   }
 
   try {
@@ -16,30 +16,30 @@ function formatOptionalDate(value: string | undefined | null): string {
 
 const DocumentApprovalPage = createApprovalPage({
   type: "document",
-  title: "退税申请审核",
-  description: "审核用户提交的退税申请，确认纳税信息与退款原因后再进行处理。",
-  emptyLabel: "当前没有待审核的退税申请。",
+  title: "Tax Refund Application Reviews",
+  description: "Review tax refund applications and verify the taxpayer details before processing.",
+  emptyLabel: "There are no tax refund applications awaiting review.",
   columns: [
     {
-      header: "纳税人",
+      header: "Taxpayer",
       render: (submission) => (
         <div className="space-y-1">
           <p className="font-medium text-gray-900 dark:text-gray-100">
             {submission.payload.taxpayerName ?? submission.payload.documentType ?? "—"}
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
-            原因：{submission.payload.refundReason ?? submission.payload.justification ?? "—"}
+            Reason: {submission.payload.refundReason ?? submission.payload.justification ?? "—"}
           </p>
         </div>
       ),
     },
     {
-      header: "申请年份",
+      header: "Filing Year",
       className: "whitespace-nowrap",
       render: (submission) => submission.payload.taxYear ?? "—",
     },
     {
-      header: "预计到账日期",
+      header: "Expected Payout Date",
       className: "whitespace-nowrap",
       render: (submission) =>
         formatOptionalDate(
@@ -47,12 +47,12 @@ const DocumentApprovalPage = createApprovalPage({
         ),
     },
     {
-      header: "提交账号",
+      header: "Submitted By",
       className: "whitespace-nowrap",
       render: (submission) => submission.submittedBy,
     },
     {
-      header: "状态",
+      header: "Status",
       className: "whitespace-nowrap",
       render: (submission) => (
         <span className="capitalize text-gray-900 dark:text-gray-100">
@@ -64,25 +64,25 @@ const DocumentApprovalPage = createApprovalPage({
   renderDetails: (submission) => (
     <div className="grid gap-4 md:grid-cols-2">
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">纳税人</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Taxpayer</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {submission.payload.taxpayerName ?? submission.payload.documentType ?? "—"}
         </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">申请年份</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Filing Year</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {submission.payload.taxYear ?? "—"}
         </p>
       </div>
       <div className="space-y-1 md:col-span-2">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">退款原因</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Refund Reason</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {submission.payload.refundReason ?? submission.payload.justification ?? "—"}
         </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">预计到账日期</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Expected Payout Date</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {formatOptionalDate(
             submission.payload.expectedPayoutDate ?? submission.payload.requiredBy,
@@ -90,20 +90,20 @@ const DocumentApprovalPage = createApprovalPage({
         </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交账号</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted By</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交时间</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">{new Date(submission.createdAt).toLocaleString()}</p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">状态</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
         <p className="text-sm capitalize text-gray-700 dark:text-gray-300">{submission.status}</p>
       </div>
       {submission.decisionBy ? (
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">审核人</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewer</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {submission.decisionBy}
             {submission.decidedAt

--- a/src/app/approvals/feedback/page.tsx
+++ b/src/app/approvals/feedback/page.tsx
@@ -4,22 +4,25 @@ import { createApprovalPage } from "../_components/createApprovalPage";
 import { formatDate } from "@/lib/tools";
 
 // Helper render functions
-const renderFeedbackInfo = (submission: any) => (
-  <div className="space-y-1">
-    <p className="font-medium text-gray-900 dark:text-gray-100">
-      {submission.payload.subject}
-    </p>
-    <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
-      {submission.payload.details}
-    </p>
-  </div>
-);
+const renderApplicationInfo = (submission: any) => {
+  const applicant =
+    submission.payload.applicantName ?? submission.payload.subject ?? "—";
+  const reason =
+    submission.payload.applicationReason ?? submission.payload.details ?? "—";
+
+  return (
+    <div className="space-y-1">
+      <p className="font-medium text-gray-900 dark:text-gray-100">{applicant}</p>
+      <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
+        原因：{reason}
+      </p>
+    </div>
+  );
+};
 
 const renderSubmittedInfo = (submission: any) => (
   <div className="space-y-1">
-    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-      Submitted
-    </h3>
+    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交时间</h3>
     <p className="text-sm text-gray-700 dark:text-gray-300">
       {formatDate(submission.createdAt)}
     </p>
@@ -29,9 +32,7 @@ const renderSubmittedInfo = (submission: any) => (
 const renderReviewerInfo = (submission: any) =>
   submission.decisionBy ? (
     <div className="space-y-1">
-      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-        Reviewed by
-      </h3>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">审核人</h3>
       <p className="text-sm text-gray-700 dark:text-gray-300">
         {submission.decisionBy}
         {submission.decidedAt ? ` · ${formatDate(submission.decidedAt)}` : ""}
@@ -42,27 +43,32 @@ const renderReviewerInfo = (submission: any) =>
 // Main component
 const FeedbackApprovalPage = createApprovalPage({
   type: "feedback",
-  title: "Feedback Service Approvals",
-  description:
-    "Review feedback submissions from end users and approve them once they have been addressed.",
-  emptyLabel: "There are no feedback submissions waiting for review.",
+  title: "驾照申请审核",
+  description: "审核用户提交的驾照申请，确认信息无误后再进行批准。",
+  emptyLabel: "当前没有待审核的驾照申请。",
   columns: [
     {
-      header: "Feedback",
-      render: renderFeedbackInfo,
+      header: "申请人",
+      render: renderApplicationInfo,
     },
     {
-      header: "Submitted by",
+      header: "驾照类型",
       className: "whitespace-nowrap",
-      render: (submission) => submission.submittedBy,
+      render: (submission) => submission.payload.licenseType ?? "—",
     },
     {
-      header: "Submitted",
+      header: "联系电话",
+      className: "whitespace-nowrap",
+      render: (submission) =>
+        submission.payload.contactNumber ?? submission.payload.contactMethod ?? "—",
+    },
+    {
+      header: "提交时间",
       className: "whitespace-nowrap",
       render: (submission) => formatDate(submission.createdAt),
     },
     {
-      header: "Status",
+      header: "状态",
       className: "whitespace-nowrap",
       render: (submission) => (
         <span className="capitalize text-gray-900 dark:text-gray-100">
@@ -74,31 +80,43 @@ const FeedbackApprovalPage = createApprovalPage({
   renderDetails: (submission) => (
     <div className="grid gap-4 md:grid-cols-2">
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Feedback details</h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.payload.details}</p>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">申请人</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {submission.payload.applicantName ?? submission.payload.subject ?? "—"}
+        </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Subject</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">驾照类型</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
-          {submission.payload.subject}
+          {submission.payload.licenseType ?? "—"}
         </p>
       </div>
 
-      {submission.payload.contactMethod && (
+      <div className="space-y-1 md:col-span-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">申请原因</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {submission.payload.applicationReason ?? submission.payload.details ?? "—"}
+        </p>
+      </div>
+
+      {submission.payload.contactNumber || submission.payload.contactMethod ? (
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Preferred contact</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">联系电话</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
-            {submission.payload.contactMethod}
+            {submission.payload.contactNumber ?? submission.payload.contactMethod}
           </p>
         </div>
-      )}
+      ) : null}
+
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交账号</h3>
+        <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
+      </div>
 
       {renderSubmittedInfo(submission)}
 
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-          Status
-        </h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">状态</h3>
         <p className="text-sm capitalize text-gray-700 dark:text-gray-300">
           {submission.status}
         </p>

--- a/src/app/approvals/feedback/page.tsx
+++ b/src/app/approvals/feedback/page.tsx
@@ -14,7 +14,7 @@ const renderApplicationInfo = (submission: any) => {
     <div className="space-y-1">
       <p className="font-medium text-gray-900 dark:text-gray-100">{applicant}</p>
       <p className="text-xs text-gray-600 dark:text-gray-300 break-words">
-        原因：{reason}
+        Reason: {reason}
       </p>
     </div>
   );
@@ -22,7 +22,7 @@ const renderApplicationInfo = (submission: any) => {
 
 const renderSubmittedInfo = (submission: any) => (
   <div className="space-y-1">
-    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交时间</h3>
+    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted</h3>
     <p className="text-sm text-gray-700 dark:text-gray-300">
       {formatDate(submission.createdAt)}
     </p>
@@ -32,7 +32,7 @@ const renderSubmittedInfo = (submission: any) => (
 const renderReviewerInfo = (submission: any) =>
   submission.decisionBy ? (
     <div className="space-y-1">
-      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">审核人</h3>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Reviewer</h3>
       <p className="text-sm text-gray-700 dark:text-gray-300">
         {submission.decisionBy}
         {submission.decidedAt ? ` · ${formatDate(submission.decidedAt)}` : ""}
@@ -43,32 +43,32 @@ const renderReviewerInfo = (submission: any) =>
 // Main component
 const FeedbackApprovalPage = createApprovalPage({
   type: "feedback",
-  title: "驾照申请审核",
-  description: "审核用户提交的驾照申请，确认信息无误后再进行批准。",
-  emptyLabel: "当前没有待审核的驾照申请。",
+  title: "Driver's License Application Reviews",
+  description: "Review driver's license applications and confirm the details before approving.",
+  emptyLabel: "There are no driver's license applications awaiting review.",
   columns: [
     {
-      header: "申请人",
+      header: "Applicant",
       render: renderApplicationInfo,
     },
     {
-      header: "驾照类型",
+      header: "License Class",
       className: "whitespace-nowrap",
       render: (submission) => submission.payload.licenseType ?? "—",
     },
     {
-      header: "联系电话",
+      header: "Contact Number",
       className: "whitespace-nowrap",
       render: (submission) =>
         submission.payload.contactNumber ?? submission.payload.contactMethod ?? "—",
     },
     {
-      header: "提交时间",
+      header: "Submitted",
       className: "whitespace-nowrap",
       render: (submission) => formatDate(submission.createdAt),
     },
     {
-      header: "状态",
+      header: "Status",
       className: "whitespace-nowrap",
       render: (submission) => (
         <span className="capitalize text-gray-900 dark:text-gray-100">
@@ -80,20 +80,20 @@ const FeedbackApprovalPage = createApprovalPage({
   renderDetails: (submission) => (
     <div className="grid gap-4 md:grid-cols-2">
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">申请人</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Applicant</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {submission.payload.applicantName ?? submission.payload.subject ?? "—"}
         </p>
       </div>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">驾照类型</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">License Class</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {submission.payload.licenseType ?? "—"}
         </p>
       </div>
 
       <div className="space-y-1 md:col-span-2">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">申请原因</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Application Reason</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">
           {submission.payload.applicationReason ?? submission.payload.details ?? "—"}
         </p>
@@ -101,7 +101,7 @@ const FeedbackApprovalPage = createApprovalPage({
 
       {submission.payload.contactNumber || submission.payload.contactMethod ? (
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">联系电话</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Contact Number</h3>
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {submission.payload.contactNumber ?? submission.payload.contactMethod}
           </p>
@@ -109,14 +109,14 @@ const FeedbackApprovalPage = createApprovalPage({
       ) : null}
 
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">提交账号</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Submitted By</h3>
         <p className="text-sm text-gray-700 dark:text-gray-300">{submission.submittedBy}</p>
       </div>
 
       {renderSubmittedInfo(submission)}
 
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">状态</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h3>
         <p className="text-sm capitalize text-gray-700 dark:text-gray-300">
           {submission.status}
         </p>

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -69,7 +69,7 @@ export default function BookingPage() {
       if (submissionError instanceof Error) {
         setError(submissionError.message);
       } else {
-        setError("无法加载医疗证明申请记录。");
+        setError("Unable to load medical certificate applications.");
       }
     } finally {
       setIsLoading(false);
@@ -150,19 +150,19 @@ export default function BookingPage() {
         };
 
         if (!payload.patientName) {
-          throw new Error("请填写患者姓名。");
+          throw new Error("Please enter the patient's name.");
         }
 
         if (!payload.appointmentDate) {
-          throw new Error("请选择希望开具日期。");
+          throw new Error("Please choose the desired issuance date.");
         }
 
         if (!payload.appointmentTime) {
-          throw new Error("请选择希望时间。");
+          throw new Error("Please choose the desired time.");
         }
 
         if (!payload.certificatePurpose) {
-          throw new Error("请填写开具用途说明。");
+          throw new Error("Please describe the purpose for the certificate.");
         }
 
         const record = await createSubmission("booking", payload, currentUser);
@@ -172,13 +172,13 @@ export default function BookingPage() {
         setAppointmentDate("");
         setAppointmentTime("");
         setCertificatePurpose("");
-        setMessage("医疗证明申请提交成功。");
+        setMessage("Medical certificate application submitted successfully.");
         void refreshSubmissions();
       } catch (submissionError) {
         if (submissionError instanceof Error) {
           setError(submissionError.message);
         } else {
-          setError("提交医疗证明申请时发生未知错误。");
+          setError("An unknown error occurred while submitting the medical certificate application.");
         }
       }
     },
@@ -188,8 +188,8 @@ export default function BookingPage() {
   if (!currentUser) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">医疗证明申请</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">请先登录后再提交医疗证明申请。</p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Medical Certificate Application</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Please sign in before submitting a medical certificate application.</p>
       </div>
     );
   }
@@ -198,9 +198,9 @@ export default function BookingPage() {
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="mb-6 space-y-1">
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">医疗证明申请</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Medical Certificate Application</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            填写患者信息与开具用途，我们会在审核后尽快反馈结果。
+            Provide the patient details and explain why the certificate is needed. We will respond after the review.
           </p>
         </div>
 
@@ -219,7 +219,7 @@ export default function BookingPage() {
         <form className="space-y-5" onSubmit={handleSubmit}>
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="patientName">
-              患者姓名
+              Patient Name
             </label>
             <input
               id="patientName"
@@ -227,7 +227,7 @@ export default function BookingPage() {
               value={patientName}
               onChange={handlePatientNameChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="请输入患者姓名"
+              placeholder="Enter the patient name"
               required
             />
           </div>
@@ -235,7 +235,7 @@ export default function BookingPage() {
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="appointmentDate">
-                希望开具日期
+                Preferred Date
               </label>
               <input
                 type="date"
@@ -250,7 +250,7 @@ export default function BookingPage() {
 
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="appointmentTime">
-                希望时间
+                Preferred Time
               </label>
               <input
                 type="time"
@@ -266,7 +266,7 @@ export default function BookingPage() {
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="certificatePurpose">
-              开具用途说明
+              Purpose for Certificate
             </label>
             <textarea
               id="certificatePurpose"
@@ -274,7 +274,7 @@ export default function BookingPage() {
               value={certificatePurpose}
               onChange={handleCertificatePurposeChange}
               className="h-24 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="请描述需要医疗证明的原因"
+              placeholder="Describe why you need the medical certificate"
               required
             />
           </div>
@@ -283,26 +283,26 @@ export default function BookingPage() {
             type="submit"
             className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            提交申请
+            Submit Application
           </button>
         </form>
       </div>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">申请记录</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Application History</h2>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          查看以往的医疗证明申请与审核状态。
+          Review your previous medical certificate applications and their approval status.
         </p>
 
         <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">患者姓名</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">预约时间</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">用途说明</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">提交时间</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">状态</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Patient Name</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Appointment Slot</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Purpose</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
@@ -312,7 +312,7 @@ export default function BookingPage() {
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
                     colSpan={5}
                   >
-                    正在加载申请记录…
+                    Loading applications…
                   </td>
                 </tr>
               ) : submissions.length === 0 ? (
@@ -321,7 +321,7 @@ export default function BookingPage() {
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
                     colSpan={5}
                   >
-                    目前还没有提交过医疗证明申请。
+                    You have not submitted any medical certificate applications yet.
                   </td>
                 </tr>
               ) : (

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -21,7 +21,7 @@ import {
   SUBMISSIONS_STORAGE_KEY,
 } from "@/services/submissionService";
 
-function formatPreferredSlot(date: string, time: string): string {
+function formatAppointmentSlot(date: string, time: string): string {
   if (!date) {
     return "";
   }
@@ -34,7 +34,7 @@ function formatPreferredSlot(date: string, time: string): string {
 
     return `${datePart} ${time}`;
   } catch (error) {
-    return `${date} ${time}`.trim();
+        return `${date} ${time}`.trim();
   }
 }
 
@@ -44,10 +44,10 @@ export default function BookingPage() {
   );
   const [submissions, setSubmissions] = useState<SubmissionRecord<"booking">[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [serviceName, setServiceName] = useState("");
-  const [preferredDate, setPreferredDate] = useState("");
-  const [preferredTime, setPreferredTime] = useState("");
-  const [notes, setNotes] = useState("");
+  const [patientName, setPatientName] = useState("");
+  const [appointmentDate, setAppointmentDate] = useState("");
+  const [appointmentTime, setAppointmentTime] = useState("");
+  const [certificatePurpose, setCertificatePurpose] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -69,7 +69,7 @@ export default function BookingPage() {
       if (submissionError instanceof Error) {
         setError(submissionError.message);
       } else {
-        setError("Unable to load booking history.");
+        setError("无法加载医疗证明申请记录。");
       }
     } finally {
       setIsLoading(false);
@@ -107,30 +107,30 @@ export default function BookingPage() {
     };
   }, [refreshSubmissions]);
 
-  const handleServiceNameChange = useCallback(
+  const handlePatientNameChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setServiceName(event.target.value);
+      setPatientName(event.target.value);
     },
     [],
   );
 
-  const handlePreferredDateChange = useCallback(
+  const handleAppointmentDateChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setPreferredDate(event.target.value);
+      setAppointmentDate(event.target.value);
     },
     [],
   );
 
-  const handlePreferredTimeChange = useCallback(
+  const handleAppointmentTimeChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setPreferredTime(event.target.value);
+      setAppointmentTime(event.target.value);
     },
     [],
   );
 
-  const handleNotesChange = useCallback(
+  const handleCertificatePurposeChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      setNotes(event.target.value);
+      setCertificatePurpose(event.target.value);
     },
     [],
   );
@@ -143,53 +143,53 @@ export default function BookingPage() {
 
       try {
         const payload: BookingPayload = {
-          serviceName: serviceName.trim(),
-          preferredDate,
-          preferredTime,
-          notes: notes.trim() || undefined,
+          patientName: patientName.trim(),
+          appointmentDate,
+          appointmentTime,
+          certificatePurpose: certificatePurpose.trim(),
         };
 
-        if (!payload.serviceName) {
-          throw new Error("Service name is required.");
+        if (!payload.patientName) {
+          throw new Error("请填写患者姓名。");
         }
 
-        if (!payload.preferredDate) {
-          throw new Error("Preferred date is required.");
+        if (!payload.appointmentDate) {
+          throw new Error("请选择希望开具日期。");
         }
 
-        if (!payload.preferredTime) {
-          throw new Error("Preferred time is required.");
+        if (!payload.appointmentTime) {
+          throw new Error("请选择希望时间。");
+        }
+
+        if (!payload.certificatePurpose) {
+          throw new Error("请填写开具用途说明。");
         }
 
         const record = await createSubmission("booking", payload, currentUser);
         setSubmissions((previous) => [record, ...previous]);
 
-        setServiceName("");
-        setPreferredDate("");
-        setPreferredTime("");
-        setNotes("");
-        setMessage("Booking request submitted successfully.");
+        setPatientName("");
+        setAppointmentDate("");
+        setAppointmentTime("");
+        setCertificatePurpose("");
+        setMessage("医疗证明申请提交成功。");
         void refreshSubmissions();
       } catch (submissionError) {
         if (submissionError instanceof Error) {
           setError(submissionError.message);
         } else {
-          setError(
-            "An unexpected error occurred while creating the booking request.",
-          );
+          setError("提交医疗证明申请时发生未知错误。");
         }
       }
     },
-    [currentUser, notes, preferredDate, preferredTime, refreshSubmissions, serviceName],
+    [appointmentDate, appointmentTime, certificatePurpose, currentUser, patientName, refreshSubmissions],
   );
 
   if (!currentUser) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Booking Service</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">
-          You need to sign in before scheduling a booking.
-        </p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">医疗证明申请</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">请先登录后再提交医疗证明申请。</p>
       </div>
     );
   }
@@ -198,9 +198,9 @@ export default function BookingPage() {
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="mb-6 space-y-1">
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Booking Service</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">医疗证明申请</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            Request an appointment with our team. We will confirm once it is reviewed.
+            填写患者信息与开具用途，我们会在审核后尽快反馈结果。
           </p>
         </div>
 
@@ -218,46 +218,46 @@ export default function BookingPage() {
 
         <form className="space-y-5" onSubmit={handleSubmit}>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="serviceName">
-              Service name
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="patientName">
+              患者姓名
             </label>
             <input
-              id="serviceName"
-              name="serviceName"
-              value={serviceName}
-              onChange={handleServiceNameChange}
+              id="patientName"
+              name="patientName"
+              value={patientName}
+              onChange={handlePatientNameChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Consultation, onboarding, etc."
+              placeholder="请输入患者姓名"
               required
             />
           </div>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="preferredDate">
-                Preferred date
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="appointmentDate">
+                希望开具日期
               </label>
               <input
                 type="date"
-                id="preferredDate"
-                name="preferredDate"
-                value={preferredDate}
-                onChange={handlePreferredDateChange}
+                id="appointmentDate"
+                name="appointmentDate"
+                value={appointmentDate}
+                onChange={handleAppointmentDateChange}
                 className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
                 required
               />
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="preferredTime">
-                Preferred time
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="appointmentTime">
+                希望时间
               </label>
               <input
                 type="time"
-                id="preferredTime"
-                name="preferredTime"
-                value={preferredTime}
-                onChange={handlePreferredTimeChange}
+                id="appointmentTime"
+                name="appointmentTime"
+                value={appointmentTime}
+                onChange={handleAppointmentTimeChange}
                 className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
                 required
               />
@@ -265,16 +265,17 @@ export default function BookingPage() {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="notes">
-              Additional notes (optional)
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="certificatePurpose">
+              开具用途说明
             </label>
             <textarea
-              id="notes"
-              name="notes"
-              value={notes}
-              onChange={handleNotesChange}
+              id="certificatePurpose"
+              name="certificatePurpose"
+              value={certificatePurpose}
+              onChange={handleCertificatePurposeChange}
               className="h-24 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Share any important context for the appointment"
+              placeholder="请描述需要医疗证明的原因"
+              required
             />
           </div>
 
@@ -282,25 +283,26 @@ export default function BookingPage() {
             type="submit"
             className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            Submit booking request
+            提交申请
           </button>
         </form>
       </div>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Submission history</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">申请记录</h2>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          Track the status of your booking requests.
+          查看以往的医疗证明申请与审核状态。
         </p>
 
         <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Service</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Preferred slot</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted at</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">患者姓名</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">预约时间</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">用途说明</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">提交时间</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">状态</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
@@ -308,40 +310,59 @@ export default function BookingPage() {
                 <tr>
                   <td
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
-                    colSpan={4}
+                    colSpan={5}
                   >
-                    Loading submissions...
+                    正在加载申请记录…
                   </td>
                 </tr>
               ) : submissions.length === 0 ? (
                 <tr>
                   <td
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
-                    colSpan={4}
+                    colSpan={5}
                   >
-                    You have not submitted any booking requests yet.
+                    目前还没有提交过医疗证明申请。
                   </td>
                 </tr>
               ) : (
-                submissions.map((submission) => (
-                  <tr key={submission.id} className="bg-white dark:bg-gray-950">
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
-                      {submission.payload.serviceName}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
-                      {formatPreferredSlot(
-                        submission.payload.preferredDate,
-                        submission.payload.preferredTime,
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
-                      {submission.status}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
-                      {new Date(submission.createdAt).toLocaleString()}
-                    </td>
-                  </tr>
-                ))
+                submissions.map((submission) => {
+                  const patient =
+                    submission.payload.patientName ??
+                    submission.payload.serviceName ??
+                    "—";
+                  const appointment = formatAppointmentSlot(
+                    submission.payload.appointmentDate ??
+                      submission.payload.preferredDate ??
+                      "",
+                    submission.payload.appointmentTime ??
+                      submission.payload.preferredTime ??
+                      "",
+                  );
+                  const purpose =
+                    submission.payload.certificatePurpose ??
+                    submission.payload.notes ??
+                    "—";
+
+                  return (
+                    <tr key={submission.id} className="bg-white dark:bg-gray-950">
+                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                        {patient}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {appointment}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {purpose}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {new Date(submission.createdAt).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                        {submission.status}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -27,9 +27,10 @@ export default function DocumentRequestPage() {
   );
   const [submissions, setSubmissions] = useState<SubmissionRecord<"document">[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [documentType, setDocumentType] = useState("");
-  const [justification, setJustification] = useState("");
-  const [requiredBy, setRequiredBy] = useState("");
+  const [taxpayerName, setTaxpayerName] = useState("");
+  const [taxYear, setTaxYear] = useState("");
+  const [refundReason, setRefundReason] = useState("");
+  const [expectedPayoutDate, setExpectedPayoutDate] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,7 +52,7 @@ export default function DocumentRequestPage() {
       if (submissionError instanceof Error) {
         setError(submissionError.message);
       } else {
-        setError("Unable to load document history.");
+        setError("无法加载退税申请记录。");
       }
     } finally {
       setIsLoading(false);
@@ -89,23 +90,30 @@ export default function DocumentRequestPage() {
     };
   }, [refreshSubmissions]);
 
-  const handleDocumentTypeChange = useCallback(
+  const handleTaxpayerNameChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setDocumentType(event.target.value);
+      setTaxpayerName(event.target.value);
     },
     [],
   );
 
-  const handleJustificationChange = useCallback(
+  const handleTaxYearChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setTaxYear(event.target.value);
+    },
+    [],
+  );
+
+  const handleRefundReasonChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      setJustification(event.target.value);
+      setRefundReason(event.target.value);
     },
     [],
   );
 
-  const handleRequiredByChange = useCallback(
+  const handleExpectedPayoutDateChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setRequiredBy(event.target.value);
+      setExpectedPayoutDate(event.target.value);
     },
     [],
   );
@@ -118,47 +126,49 @@ export default function DocumentRequestPage() {
 
       try {
         const payload: DocumentPayload = {
-          documentType: documentType.trim(),
-          justification: justification.trim(),
-          requiredBy: requiredBy || undefined,
+          taxpayerName: taxpayerName.trim(),
+          taxYear: taxYear.trim(),
+          refundReason: refundReason.trim(),
+          expectedPayoutDate: expectedPayoutDate || undefined,
         };
 
-        if (!payload.documentType) {
-          throw new Error("Document type is required.");
+        if (!payload.taxpayerName) {
+          throw new Error("请填写纳税人姓名。");
         }
 
-        if (!payload.justification) {
-          throw new Error("Justification is required.");
+        if (!payload.taxYear) {
+          throw new Error("请填写申请年份。");
+        }
+
+        if (!payload.refundReason) {
+          throw new Error("请填写退款原因。");
         }
 
         const record = await createSubmission("document", payload, currentUser);
         setSubmissions((previous) => [record, ...previous]);
 
-        setDocumentType("");
-        setJustification("");
-        setRequiredBy("");
-        setMessage("Document request submitted successfully.");
+        setTaxpayerName("");
+        setTaxYear("");
+        setRefundReason("");
+        setExpectedPayoutDate("");
+        setMessage("退税申请提交成功。");
         void refreshSubmissions();
       } catch (submissionError) {
         if (submissionError instanceof Error) {
           setError(submissionError.message);
         } else {
-          setError(
-            "An unexpected error occurred while submitting the document request.",
-          );
+          setError("提交退税申请时发生未知错误。");
         }
       }
     },
-    [currentUser, documentType, justification, refreshSubmissions, requiredBy],
+    [currentUser, expectedPayoutDate, refundReason, refreshSubmissions, taxpayerName, taxYear],
   );
 
   if (!currentUser) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Document Request Service</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">
-          You need to sign in before requesting documents.
-        </p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">退税申请</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">请先登录后再提交退税申请。</p>
       </div>
     );
   }
@@ -167,9 +177,9 @@ export default function DocumentRequestPage() {
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="mb-6 space-y-1">
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Document Request Service</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">退税申请</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            Request certificates, letters, or other documents from our team.
+            填写纳税信息和退款原因，我们会尽快审核您的退税申请。
           </p>
         </div>
 
@@ -187,45 +197,60 @@ export default function DocumentRequestPage() {
 
         <form className="space-y-5" onSubmit={handleSubmit}>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="documentType">
-              Document type
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="taxpayerName">
+              纳税人姓名
             </label>
             <input
-              id="documentType"
-              name="documentType"
-              value={documentType}
-              onChange={handleDocumentTypeChange}
+              id="taxpayerName"
+              name="taxpayerName"
+              value={taxpayerName}
+              onChange={handleTaxpayerNameChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Enrollment letter, transcript, etc."
+              placeholder="请输入纳税人姓名"
               required
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="justification">
-              Justification
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="taxYear">
+              申请年份
+            </label>
+            <input
+              id="taxYear"
+              name="taxYear"
+              value={taxYear}
+              onChange={handleTaxYearChange}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="例如 2023"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="refundReason">
+              退款原因
             </label>
             <textarea
-              id="justification"
-              name="justification"
-              value={justification}
-              onChange={handleJustificationChange}
+              id="refundReason"
+              name="refundReason"
+              value={refundReason}
+              onChange={handleRefundReasonChange}
               className="h-28 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Explain why you need this document"
+              placeholder="请描述申请退税的原因"
               required
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="requiredBy">
-              Required by (optional)
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="expectedPayoutDate">
+              预计到账日期（选填）
             </label>
             <input
               type="date"
-              id="requiredBy"
-              name="requiredBy"
-              value={requiredBy}
-              onChange={handleRequiredByChange}
+              id="expectedPayoutDate"
+              name="expectedPayoutDate"
+              value={expectedPayoutDate}
+              onChange={handleExpectedPayoutDateChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
             />
           </div>
@@ -234,25 +259,27 @@ export default function DocumentRequestPage() {
             type="submit"
             className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            Submit document request
+            提交申请
           </button>
         </form>
       </div>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Submission history</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">申请记录</h2>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          Track the status of your document requests.
+          查看以往的退税申请与审核状态。
         </p>
 
         <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Document</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Required by</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted at</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">纳税人</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">申请年份</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">退款原因</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">预计到账日期</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">提交时间</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">状态</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
@@ -260,39 +287,48 @@ export default function DocumentRequestPage() {
                 <tr>
                   <td
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
-                    colSpan={4}
+                    colSpan={6}
                   >
-                    Loading submissions...
+                    正在加载申请记录…
                   </td>
                 </tr>
               ) : submissions.length === 0 ? (
                 <tr>
                   <td
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
-                    colSpan={4}
+                    colSpan={6}
                   >
-                    You have not submitted any document requests yet.
+                    目前还没有提交过退税申请。
                   </td>
                 </tr>
               ) : (
-                submissions.map((submission) => (
-                  <tr key={submission.id} className="bg-white dark:bg-gray-950">
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
-                      {submission.payload.documentType}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
-                      {submission.status}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
-                      {submission.payload.requiredBy
-                        ? new Date(submission.payload.requiredBy).toLocaleDateString()
-                        : "—"}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
-                      {new Date(submission.createdAt).toLocaleString()}
-                    </td>
-                  </tr>
-                ))
+                submissions.map((submission) => {
+                  const payload = submission.payload;
+                  const taxpayer = payload.taxpayerName ?? payload.documentType ?? "—";
+                  const year = payload.taxYear ?? "—";
+                  const reason = payload.refundReason ?? payload.justification ?? "—";
+                  const expectedDate = payload.expectedPayoutDate ?? payload.requiredBy ?? "";
+                  const formattedDate = expectedDate
+                    ? new Date(
+                        expectedDate + (expectedDate.includes('T') ? '' : 'T00:00'),
+                      ).toLocaleDateString()
+                    : "—";
+
+                  return (
+                    <tr key={submission.id} className="bg-white dark:bg-gray-950">
+                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{taxpayer}</td>
+                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{year}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{reason}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{formattedDate}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {new Date(submission.createdAt).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                        {submission.status}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -52,7 +52,7 @@ export default function DocumentRequestPage() {
       if (submissionError instanceof Error) {
         setError(submissionError.message);
       } else {
-        setError("无法加载退税申请记录。");
+        setError("Unable to load tax refund applications.");
       }
     } finally {
       setIsLoading(false);
@@ -133,15 +133,15 @@ export default function DocumentRequestPage() {
         };
 
         if (!payload.taxpayerName) {
-          throw new Error("请填写纳税人姓名。");
+          throw new Error("Please enter the taxpayer's name.");
         }
 
         if (!payload.taxYear) {
-          throw new Error("请填写申请年份。");
+          throw new Error("Please enter the filing year.");
         }
 
         if (!payload.refundReason) {
-          throw new Error("请填写退款原因。");
+          throw new Error("Please describe the reason for the refund.");
         }
 
         const record = await createSubmission("document", payload, currentUser);
@@ -151,13 +151,13 @@ export default function DocumentRequestPage() {
         setTaxYear("");
         setRefundReason("");
         setExpectedPayoutDate("");
-        setMessage("退税申请提交成功。");
+        setMessage("Tax refund application submitted successfully.");
         void refreshSubmissions();
       } catch (submissionError) {
         if (submissionError instanceof Error) {
           setError(submissionError.message);
         } else {
-          setError("提交退税申请时发生未知错误。");
+          setError("An unknown error occurred while submitting the tax refund application.");
         }
       }
     },
@@ -167,8 +167,8 @@ export default function DocumentRequestPage() {
   if (!currentUser) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">退税申请</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">请先登录后再提交退税申请。</p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Tax Refund Application</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Please sign in before submitting a tax refund application.</p>
       </div>
     );
   }
@@ -177,9 +177,9 @@ export default function DocumentRequestPage() {
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="mb-6 space-y-1">
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">退税申请</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Tax Refund Application</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            填写纳税信息和退款原因，我们会尽快审核您的退税申请。
+            Provide the taxpayer details and refund justification so we can review your request quickly.
           </p>
         </div>
 
@@ -198,7 +198,7 @@ export default function DocumentRequestPage() {
         <form className="space-y-5" onSubmit={handleSubmit}>
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="taxpayerName">
-              纳税人姓名
+              Taxpayer Name
             </label>
             <input
               id="taxpayerName"
@@ -206,14 +206,14 @@ export default function DocumentRequestPage() {
               value={taxpayerName}
               onChange={handleTaxpayerNameChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="请输入纳税人姓名"
+              placeholder="Enter the taxpayer name"
               required
             />
           </div>
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="taxYear">
-              申请年份
+              Filing Year
             </label>
             <input
               id="taxYear"
@@ -221,14 +221,14 @@ export default function DocumentRequestPage() {
               value={taxYear}
               onChange={handleTaxYearChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="例如 2023"
+              placeholder="For example: 2023"
               required
             />
           </div>
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="refundReason">
-              退款原因
+              Refund Reason
             </label>
             <textarea
               id="refundReason"
@@ -236,14 +236,14 @@ export default function DocumentRequestPage() {
               value={refundReason}
               onChange={handleRefundReasonChange}
               className="h-28 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="请描述申请退税的原因"
+              placeholder="Describe why you are requesting a refund"
               required
             />
           </div>
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="expectedPayoutDate">
-              预计到账日期（选填）
+              Expected Payout Date (optional)
             </label>
             <input
               type="date"
@@ -259,27 +259,27 @@ export default function DocumentRequestPage() {
             type="submit"
             className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            提交申请
+            Submit Application
           </button>
         </form>
       </div>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">申请记录</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Application History</h2>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          查看以往的退税申请与审核状态。
+          Review your previous tax refund applications and their approval status.
         </p>
 
         <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">纳税人</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">申请年份</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">退款原因</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">预计到账日期</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">提交时间</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">状态</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Taxpayer</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Filing Year</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Refund Reason</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Expected Payout Date</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
@@ -289,7 +289,7 @@ export default function DocumentRequestPage() {
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
                     colSpan={6}
                   >
-                    正在加载申请记录…
+                    Loading applications…
                   </td>
                 </tr>
               ) : submissions.length === 0 ? (
@@ -298,7 +298,7 @@ export default function DocumentRequestPage() {
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
                     colSpan={6}
                   >
-                    目前还没有提交过退税申请。
+                    You have not submitted any tax refund applications yet.
                   </td>
                 </tr>
               ) : (

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -27,9 +27,10 @@ export default function FeedbackPage() {
   );
   const [submissions, setSubmissions] = useState<SubmissionRecord<"feedback">[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [subject, setSubject] = useState("");
-  const [details, setDetails] = useState("");
-  const [contactMethod, setContactMethod] = useState("");
+  const [applicantName, setApplicantName] = useState("");
+  const [licenseType, setLicenseType] = useState("");
+  const [applicationReason, setApplicationReason] = useState("");
+  const [contactNumber, setContactNumber] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,7 +52,7 @@ export default function FeedbackPage() {
       if (submissionError instanceof Error) {
         setError(submissionError.message);
       } else {
-        setError("Unable to load feedback history.");
+        setError("无法加载驾照申请记录。");
       }
     } finally {
       setIsLoading(false);
@@ -89,23 +90,30 @@ export default function FeedbackPage() {
     };
   }, [refreshSubmissions]);
 
-  const handleSubjectChange = useCallback(
+  const handleApplicantNameChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setSubject(event.target.value);
+      setApplicantName(event.target.value);
     },
     [],
   );
 
-  const handleDetailsChange = useCallback(
+  const handleLicenseTypeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setLicenseType(event.target.value);
+    },
+    [],
+  );
+
+  const handleApplicationReasonChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      setDetails(event.target.value);
+      setApplicationReason(event.target.value);
     },
     [],
   );
 
-  const handleContactMethodChange = useCallback(
+  const handleContactNumberChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setContactMethod(event.target.value);
+      setContactNumber(event.target.value);
     },
     [],
   );
@@ -118,17 +126,22 @@ export default function FeedbackPage() {
 
       try {
         const payload: FeedbackPayload = {
-          subject: subject.trim(),
-          details: details.trim(),
-          contactMethod: contactMethod.trim() || undefined,
+          applicantName: applicantName.trim(),
+          licenseType: licenseType.trim(),
+          applicationReason: applicationReason.trim(),
+          contactNumber: contactNumber.trim() || undefined,
         };
 
-        if (!payload.subject) {
-          throw new Error("Subject is required.");
+        if (!payload.applicantName) {
+          throw new Error("请填写申请人姓名。");
         }
 
-        if (!payload.details) {
-          throw new Error("Details are required.");
+        if (!payload.licenseType) {
+          throw new Error("请填写申请驾照类型。");
+        }
+
+        if (!payload.applicationReason) {
+          throw new Error("请填写申请原因。");
         }
 
         const record = await createSubmission(
@@ -138,29 +151,28 @@ export default function FeedbackPage() {
         );
         setSubmissions((previous) => [record, ...previous]);
 
-        setSubject("");
-        setDetails("");
-        setContactMethod("");
-        setMessage("Feedback submitted successfully.");
+        setApplicantName("");
+        setLicenseType("");
+        setApplicationReason("");
+        setContactNumber("");
+        setMessage("驾照申请提交成功。");
         void refreshSubmissions();
       } catch (submissionError) {
         if (submissionError instanceof Error) {
           setError(submissionError.message);
         } else {
-          setError("An unexpected error occurred while submitting feedback.");
+          setError("提交驾照申请时发生未知错误。");
         }
       }
     },
-    [contactMethod, currentUser, details, refreshSubmissions, subject],
+    [applicantName, applicationReason, contactNumber, currentUser, licenseType, refreshSubmissions],
   );
 
   if (!currentUser) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Feedback Service</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">
-          You need to sign in before submitting feedback.
-        </p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">驾照申请</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">请先登录后再提交驾照申请。</p>
       </div>
     );
   }
@@ -169,9 +181,9 @@ export default function FeedbackPage() {
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="mb-6 space-y-1">
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Feedback Service</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">驾照申请</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            Share your thoughts or report an issue. We review every submission carefully.
+            填写个人信息和申请原因，我们会尽快审核您的驾照申请。
           </p>
         </div>
 
@@ -189,46 +201,61 @@ export default function FeedbackPage() {
 
         <form className="space-y-5" onSubmit={handleSubmit}>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="subject">
-              Subject
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="applicantName">
+              申请人姓名
             </label>
             <input
-              id="subject"
-              name="subject"
-              value={subject}
-              onChange={handleSubjectChange}
+              id="applicantName"
+              name="applicantName"
+              value={applicantName}
+              onChange={handleApplicantNameChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Let us know how we can help"
+              placeholder="请输入身份证上的姓名"
               required
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="details">
-              Details
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="licenseType">
+              申请驾照类型
+            </label>
+            <input
+              id="licenseType"
+              name="licenseType"
+              value={licenseType}
+              onChange={handleLicenseTypeChange}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="例如 C1、C2 等"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="applicationReason">
+              申请原因
             </label>
             <textarea
-              id="details"
-              name="details"
-              value={details}
-              onChange={handleDetailsChange}
+              id="applicationReason"
+              name="applicationReason"
+              value={applicationReason}
+              onChange={handleApplicationReasonChange}
               className="h-32 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Please provide as much detail as possible"
+              placeholder="请说明申请驾照的原因"
               required
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="contactMethod">
-              Preferred contact method (optional)
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="contactNumber">
+              联系电话（选填）
             </label>
             <input
-              id="contactMethod"
-              name="contactMethod"
-              value={contactMethod}
-              onChange={handleContactMethodChange}
+              id="contactNumber"
+              name="contactNumber"
+              value={contactNumber}
+              onChange={handleContactNumberChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="Email, phone number, or other"
+              placeholder="用于通知审核结果的联系方式"
             />
           </div>
 
@@ -236,24 +263,26 @@ export default function FeedbackPage() {
             type="submit"
             className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            Submit feedback
+            提交申请
           </button>
         </form>
       </div>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Submission history</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">申请记录</h2>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          Track the status of your previous feedback submissions.
+          查看以往的驾照申请及审核进度。
         </p>
 
         <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Subject</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted at</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">申请人</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">驾照类型</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">申请原因</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">提交时间</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">状态</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
@@ -261,31 +290,52 @@ export default function FeedbackPage() {
                 <tr>
                   <td
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
-                    colSpan={3}
+                    colSpan={5}
                   >
-                    Loading submissions...
+                    正在加载申请记录…
                   </td>
                 </tr>
               ) : submissions.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400" colSpan={3}>
-                    You have not submitted any feedback yet.
+                  <td
+                    className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
+                    colSpan={5}
+                  >
+                    目前还没有提交过驾照申请。
                   </td>
                 </tr>
               ) : (
-                submissions.map((submission) => (
-                  <tr key={submission.id} className="bg-white dark:bg-gray-950">
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
-                      {submission.payload.subject}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
-                      {new Date(submission.createdAt).toLocaleString()}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
-                      {submission.status}
-                    </td>
-                  </tr>
-                ))
+                submissions.map((submission) => {
+                  const applicant =
+                    submission.payload.applicantName ??
+                    submission.payload.subject ??
+                    "—";
+                  const license = submission.payload.licenseType ?? "—";
+                  const reason =
+                    submission.payload.applicationReason ??
+                    submission.payload.details ??
+                    "—";
+
+                  return (
+                    <tr key={submission.id} className="bg-white dark:bg-gray-950">
+                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                        {applicant}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                        {license}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {reason}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {new Date(submission.createdAt).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                        {submission.status}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -52,7 +52,7 @@ export default function FeedbackPage() {
       if (submissionError instanceof Error) {
         setError(submissionError.message);
       } else {
-        setError("无法加载驾照申请记录。");
+        setError("Unable to load driver's license applications.");
       }
     } finally {
       setIsLoading(false);
@@ -133,15 +133,15 @@ export default function FeedbackPage() {
         };
 
         if (!payload.applicantName) {
-          throw new Error("请填写申请人姓名。");
+          throw new Error("Please enter the applicant's name.");
         }
 
         if (!payload.licenseType) {
-          throw new Error("请填写申请驾照类型。");
+          throw new Error("Please specify the license class.");
         }
 
         if (!payload.applicationReason) {
-          throw new Error("请填写申请原因。");
+          throw new Error("Please describe the reason for applying.");
         }
 
         const record = await createSubmission(
@@ -155,13 +155,13 @@ export default function FeedbackPage() {
         setLicenseType("");
         setApplicationReason("");
         setContactNumber("");
-        setMessage("驾照申请提交成功。");
+        setMessage("Driver's license application submitted successfully.");
         void refreshSubmissions();
       } catch (submissionError) {
         if (submissionError instanceof Error) {
           setError(submissionError.message);
         } else {
-          setError("提交驾照申请时发生未知错误。");
+          setError("An unknown error occurred while submitting the driver's license application.");
         }
       }
     },
@@ -171,8 +171,10 @@ export default function FeedbackPage() {
   if (!currentUser) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">驾照申请</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">请先登录后再提交驾照申请。</p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Driver&apos;s License Application</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Please sign in before submitting a driver&apos;s license application.
+          </p>
       </div>
     );
   }
@@ -181,9 +183,10 @@ export default function FeedbackPage() {
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="mb-6 space-y-1">
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">驾照申请</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Driver&apos;s License Application</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            填写个人信息和申请原因，我们会尽快审核您的驾照申请。
+            Provide your personal details and application reason and we will review your driver&apos;s license request as soon as
+            possible.
           </p>
         </div>
 
@@ -202,7 +205,7 @@ export default function FeedbackPage() {
         <form className="space-y-5" onSubmit={handleSubmit}>
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="applicantName">
-              申请人姓名
+              Applicant Name
             </label>
             <input
               id="applicantName"
@@ -210,14 +213,14 @@ export default function FeedbackPage() {
               value={applicantName}
               onChange={handleApplicantNameChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="请输入身份证上的姓名"
+              placeholder="Enter the name shown on your ID"
               required
             />
           </div>
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="licenseType">
-              申请驾照类型
+              License Class
             </label>
             <input
               id="licenseType"
@@ -225,14 +228,14 @@ export default function FeedbackPage() {
               value={licenseType}
               onChange={handleLicenseTypeChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="例如 C1、C2 等"
+              placeholder="For example: Class C, Class D"
               required
             />
           </div>
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="applicationReason">
-              申请原因
+              Application Reason
             </label>
             <textarea
               id="applicationReason"
@@ -240,14 +243,14 @@ export default function FeedbackPage() {
               value={applicationReason}
               onChange={handleApplicationReasonChange}
               className="h-32 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="请说明申请驾照的原因"
+              placeholder="Explain why you are applying for a driver's license"
               required
             />
           </div>
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="contactNumber">
-              联系电话（选填）
+              Contact Number (optional)
             </label>
             <input
               id="contactNumber"
@@ -255,7 +258,7 @@ export default function FeedbackPage() {
               value={contactNumber}
               onChange={handleContactNumberChange}
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-              placeholder="用于通知审核结果的联系方式"
+              placeholder="Phone number for status updates"
             />
           </div>
 
@@ -263,26 +266,26 @@ export default function FeedbackPage() {
             type="submit"
             className="inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            提交申请
+            Submit Application
           </button>
         </form>
       </div>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">申请记录</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Application History</h2>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          查看以往的驾照申请及审核进度。
+          Review your previous driver&apos;s license applications and their approval status.
         </p>
 
         <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">申请人</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">驾照类型</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">申请原因</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">提交时间</th>
-                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">状态</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Applicant</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">License Class</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Reason</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Submitted</th>
+                <th className="px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
@@ -292,7 +295,7 @@ export default function FeedbackPage() {
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
                     colSpan={5}
                   >
-                    正在加载申请记录…
+                    Loading applications…
                   </td>
                 </tr>
               ) : submissions.length === 0 ? (
@@ -301,7 +304,7 @@ export default function FeedbackPage() {
                     className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
                     colSpan={5}
                   >
-                    目前还没有提交过驾照申请。
+                    You have not submitted any driver&apos;s license applications yet.
                   </td>
                 </tr>
               ) : (

--- a/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 interface BreadcrumbProps {
   pageName: string;
 }
@@ -10,17 +8,6 @@ const Breadcrumb = ({ pageName }: BreadcrumbProps) => {
       <h2 className="text-[26px] font-bold leading-[30px] text-dark dark:text-white">
         {pageName}
       </h2>
-
-      <nav>
-        <ol className="flex items-center gap-2">
-          <li>
-            <Link className="font-medium" href="/">
-              Dashboard /
-            </Link>
-          </li>
-          <li className="font-medium text-primary">{pageName}</li>
-        </ol>
-      </nav>
     </div>
   );
 };

--- a/src/components/Layouts/header/index.tsx
+++ b/src/components/Layouts/header/index.tsx
@@ -35,7 +35,6 @@ export function Header() {
         <h1 className="mb-0.5 text-heading-5 font-bold text-dark dark:text-white">
           Dashboard
         </h1>
-        <p className="font-medium">Next.js Admin Dashboard Solution</p>
       </div>
 
       <div className="flex flex-1 items-center justify-end gap-2 min-[375px]:gap-4">

--- a/src/components/Layouts/sidebar/data/index.ts
+++ b/src/components/Layouts/sidebar/data/index.ts
@@ -38,22 +38,22 @@ function findFirstUrl(sections: SidebarSection[]): string | null {
 
 const USER_SECTIONS: SidebarSection[] = [
   {
-    label: "SERVICES",
+    label: "服务项目",
     items: [
       {
-        title: "Feedback Service",
+        title: "驾照申请",
         icon: Icons.FourCircle,
         url: "/feedback",
         items: [],
       },
       {
-        title: "Booking Service",
+        title: "医疗证明申请",
         icon: Icons.Calendar,
         url: "/booking",
         items: [],
       },
       {
-        title: "Document Request Service",
+        title: "退税申请",
         icon: Icons.Table,
         url: "/documents",
         items: [],
@@ -64,22 +64,22 @@ const USER_SECTIONS: SidebarSection[] = [
 
 const ADMIN_SECTIONS: SidebarSection[] = [
   {
-    label: "APPROVALS",
+    label: "审核中心",
     items: [
       {
-        title: "Feedback Service Approvals",
+        title: "驾照申请审核",
         icon: Icons.FourCircle,
         url: "/approvals/feedback",
         items: [],
       },
       {
-        title: "Booking Service Approvals",
+        title: "医疗证明申请审核",
         icon: Icons.Calendar,
         url: "/approvals/booking",
         items: [],
       },
       {
-        title: "Document Service Approvals",
+        title: "退税申请审核",
         icon: Icons.Table,
         url: "/approvals/documents",
         items: [],

--- a/src/components/Layouts/sidebar/data/index.ts
+++ b/src/components/Layouts/sidebar/data/index.ts
@@ -38,22 +38,22 @@ function findFirstUrl(sections: SidebarSection[]): string | null {
 
 const USER_SECTIONS: SidebarSection[] = [
   {
-    label: "服务项目",
+    label: "Services",
     items: [
       {
-        title: "驾照申请",
+        title: "Driver's License Application",
         icon: Icons.FourCircle,
         url: "/feedback",
         items: [],
       },
       {
-        title: "医疗证明申请",
+        title: "Medical Certificate Application",
         icon: Icons.Calendar,
         url: "/booking",
         items: [],
       },
       {
-        title: "退税申请",
+        title: "Tax Refund Application",
         icon: Icons.Table,
         url: "/documents",
         items: [],
@@ -64,22 +64,22 @@ const USER_SECTIONS: SidebarSection[] = [
 
 const ADMIN_SECTIONS: SidebarSection[] = [
   {
-    label: "审核中心",
+    label: "Approvals",
     items: [
       {
-        title: "驾照申请审核",
+        title: "Driver's License Reviews",
         icon: Icons.FourCircle,
         url: "/approvals/feedback",
         items: [],
       },
       {
-        title: "医疗证明申请审核",
+        title: "Medical Certificate Reviews",
         icon: Icons.Calendar,
         url: "/approvals/booking",
         items: [],
       },
       {
-        title: "退税申请审核",
+        title: "Tax Refund Reviews",
         icon: Icons.Table,
         url: "/approvals/documents",
         items: [],

--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -7,21 +7,43 @@ export type SubmissionType = "feedback" | "booking" | "document";
 export type SubmissionStatus = "pending" | "approved" | "rejected";
 
 export interface FeedbackPayload {
-  subject: string;
-  details: string;
+  applicantName: string;
+  licenseType: string;
+  applicationReason: string;
+  contactNumber?: string;
+  /** @deprecated kept for backward compatibility */
+  subject?: string;
+  /** @deprecated kept for backward compatibility */
+  details?: string;
+  /** @deprecated kept for backward compatibility */
   contactMethod?: string;
 }
 
 export interface BookingPayload {
-  serviceName: string;
-  preferredDate: string;
-  preferredTime: string;
+  patientName: string;
+  appointmentDate: string;
+  appointmentTime: string;
+  certificatePurpose: string;
+  /** @deprecated kept for backward compatibility */
+  serviceName?: string;
+  /** @deprecated kept for backward compatibility */
+  preferredDate?: string;
+  /** @deprecated kept for backward compatibility */
+  preferredTime?: string;
+  /** @deprecated kept for backward compatibility */
   notes?: string;
 }
 
 export interface DocumentPayload {
-  documentType: string;
-  justification: string;
+  taxpayerName: string;
+  taxYear: string;
+  refundReason: string;
+  expectedPayoutDate?: string;
+  /** @deprecated kept for backward compatibility */
+  documentType?: string;
+  /** @deprecated kept for backward compatibility */
+  justification?: string;
+  /** @deprecated kept for backward compatibility */
   requiredBy?: string;
 }
 


### PR DESCRIPTION
## Summary
- remove the breadcrumb trail from the shared header component
- rename sidebar service entries and approvals to the localized application names
- redesign each service form, history table, and approval view for the驾照申请、医疗证明申请、退税申请 flows with new fields and messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef508f90dc83238cc81c98d500e9e5